### PR TITLE
rollback to string id

### DIFF
--- a/app/routes/defillama/v1/volume.mjs
+++ b/app/routes/defillama/v1/volume.mjs
@@ -38,7 +38,7 @@ export default async (fastify, opts) => {
       },
     },
     handler: async (request, reply) => {
-      const asset = request.params.asset ? request.params.asset : null;
+      const asset = request.params.asset ? request.params.asset.toString() : null;
 
       const sqlQuery = sqlQueries.defillamaVolume({ asset });
 

--- a/app/routes/defillama/v1/volume.mjs
+++ b/app/routes/defillama/v1/volume.mjs
@@ -38,7 +38,10 @@ export default async (fastify, opts) => {
       },
     },
     handler: async (request, reply) => {
-      const asset = request.params.asset ? request.params.asset.toString() : null;
+      const asset =
+        request.params.asset !== undefined && request.params.asset !== null
+          ? request.params.asset
+          : null;
 
       const sqlQuery = sqlQueries.defillamaVolume({ asset });
 

--- a/app/routes/hydradx-ui/v1/stats/charts/lrna.mjs
+++ b/app/routes/hydradx-ui/v1/stats/charts/lrna.mjs
@@ -35,7 +35,7 @@ export default async (fastify, opts) => {
       },
     },
     handler: async (request, reply) => {
-      const asset = request.params.asset ? request.params.asset : null;
+      const asset = request.params.asset ? request.params.asset.toString() : null;
 
       const sqlQuery = sqlQueries.statsChartLrna();
 

--- a/app/routes/hydradx-ui/v1/stats/charts/lrna.mjs
+++ b/app/routes/hydradx-ui/v1/stats/charts/lrna.mjs
@@ -35,7 +35,10 @@ export default async (fastify, opts) => {
       },
     },
     handler: async (request, reply) => {
-      const asset = request.params.asset ? request.params.asset.toString() : null;
+      const asset =
+        request.params.asset !== undefined && request.params.asset !== null
+          ? request.params.asset.toString()
+          : null;
 
       const sqlQuery = sqlQueries.statsChartLrna();
 

--- a/app/routes/hydradx-ui/v1/stats/charts/tvl.mjs
+++ b/app/routes/hydradx-ui/v1/stats/charts/tvl.mjs
@@ -23,7 +23,7 @@ export default async (fastify, opts) => {
         type: "object",
         properties: {
           asset: {
-            type: "string",
+            type: "integer",
             description: "Asset (id). Leave empty for all assets.",
           },
         },
@@ -43,7 +43,10 @@ export default async (fastify, opts) => {
       },
     },
     handler: async (request, reply) => {
-      const asset = request.params.asset ? request.params.asset.toString() : null;
+      const asset =
+        request.params.asset !== undefined && request.params.asset !== null
+          ? request.params.asset.toString()
+          : null;
 
       const sqlQuery = sqlQueries.statsChartTvl({ asset });
 

--- a/app/routes/hydradx-ui/v1/stats/charts/tvl.mjs
+++ b/app/routes/hydradx-ui/v1/stats/charts/tvl.mjs
@@ -43,7 +43,7 @@ export default async (fastify, opts) => {
       },
     },
     handler: async (request, reply) => {
-      const asset = request.params.asset ? request.params.asset : null;
+      const asset = request.params.asset ? request.params.asset.toString() : null;
 
       const sqlQuery = sqlQueries.statsChartTvl({ asset });
 

--- a/app/routes/hydradx-ui/v1/stats/charts/tvl.mjs
+++ b/app/routes/hydradx-ui/v1/stats/charts/tvl.mjs
@@ -23,7 +23,7 @@ export default async (fastify, opts) => {
         type: "object",
         properties: {
           asset: {
-            type: "integer",
+            type: "string",
             description: "Asset (id). Leave empty for all assets.",
           },
         },

--- a/app/routes/hydradx-ui/v1/stats/charts/volume.mjs
+++ b/app/routes/hydradx-ui/v1/stats/charts/volume.mjs
@@ -24,7 +24,7 @@ export default async (fastify, opts) => {
         type: "object",
         properties: {
           asset: {
-            type: "string",
+            type: "integer",
             description: "Asset (id). Leave empty for all assets.",
           },
         },
@@ -54,7 +54,10 @@ export default async (fastify, opts) => {
       },
     },
     handler: async (request, reply) => {
-      const asset = request.params.asset ? request.params.asset.toString() : null;
+      const asset =
+        request.params.asset !== undefined && request.params.asset !== null
+          ? request.params.asset.toString()
+          : null;
       const timeframe = request.query.timeframe;
 
       const sqlQuery = sqlQueries.statsChartVolume({ asset, timeframe });

--- a/app/routes/hydradx-ui/v1/stats/charts/volume.mjs
+++ b/app/routes/hydradx-ui/v1/stats/charts/volume.mjs
@@ -24,7 +24,7 @@ export default async (fastify, opts) => {
         type: "object",
         properties: {
           asset: {
-            type: "integer",
+            type: "string",
             description: "Asset (id). Leave empty for all assets.",
           },
         },

--- a/app/routes/hydradx-ui/v1/stats/charts/volume.mjs
+++ b/app/routes/hydradx-ui/v1/stats/charts/volume.mjs
@@ -54,7 +54,7 @@ export default async (fastify, opts) => {
       },
     },
     handler: async (request, reply) => {
-      const asset = request.params.asset ? request.params.asset : null;
+      const asset = request.params.asset ? request.params.asset.toString() : null;
       const timeframe = request.query.timeframe;
 
       const sqlQuery = sqlQueries.statsChartVolume({ asset, timeframe });

--- a/app/routes/hydradx-ui/v1/stats/fees.mjs
+++ b/app/routes/hydradx-ui/v1/stats/fees.mjs
@@ -21,7 +21,7 @@ export default async (fastify, opts) => {
         type: "object",
         properties: {
           asset: {
-            type: "integer",
+            type: "string",
             description: "Asset (id). Leave empty for all assets.",
           },
         },

--- a/app/routes/hydradx-ui/v1/stats/fees.mjs
+++ b/app/routes/hydradx-ui/v1/stats/fees.mjs
@@ -51,7 +51,7 @@ export default async (fastify, opts) => {
       },
     },
     handler: async (request, reply) => {
-      const asset = request.params.asset ? request.params.asset : null;
+      const asset = request.params.asset ? request.params.asset.toString() : null;
       const timeframe = request.query.timeframe;
 
       const sqlQuery = sqlQueries.statsFees({ asset, timeframe });

--- a/app/routes/hydradx-ui/v1/stats/fees.mjs
+++ b/app/routes/hydradx-ui/v1/stats/fees.mjs
@@ -21,7 +21,7 @@ export default async (fastify, opts) => {
         type: "object",
         properties: {
           asset: {
-            type: "string",
+            type: "integer",
             description: "Asset (id). Leave empty for all assets.",
           },
         },
@@ -51,7 +51,10 @@ export default async (fastify, opts) => {
       },
     },
     handler: async (request, reply) => {
-      const asset = request.params.asset ? request.params.asset.toString() : null;
+      const asset =
+        request.params.asset !== undefined && request.params.asset !== null
+          ? request.params.asset.toString()
+          : null;
       const timeframe = request.query.timeframe;
 
       const sqlQuery = sqlQueries.statsFees({ asset, timeframe });

--- a/app/routes/hydradx-ui/v1/stats/price.mjs
+++ b/app/routes/hydradx-ui/v1/stats/price.mjs
@@ -20,7 +20,7 @@ export default async (fastify, opts) => {
         type: "object",
         properties: {
           asset: {
-            type: "string",
+            type: "integer",
             description: "Asset (id)",
           },
         },
@@ -39,7 +39,10 @@ export default async (fastify, opts) => {
       },
     },
     handler: async (request, reply) => {
-      const asset = request.params.asset ? request.params.asset.toString() : null;
+      const asset =
+        request.params.asset !== undefined && request.params.asset !== null
+          ? request.params.asset.toString()
+          : null;
 
       const sqlQuery = sqlQueries.statsPrice({ asset });
 

--- a/app/routes/hydradx-ui/v1/stats/price.mjs
+++ b/app/routes/hydradx-ui/v1/stats/price.mjs
@@ -20,7 +20,7 @@ export default async (fastify, opts) => {
         type: "object",
         properties: {
           asset: {
-            type: "integer",
+            type: "string",
             description: "Asset (id)",
           },
         },

--- a/app/routes/hydradx-ui/v1/stats/price.mjs
+++ b/app/routes/hydradx-ui/v1/stats/price.mjs
@@ -39,7 +39,7 @@ export default async (fastify, opts) => {
       },
     },
     handler: async (request, reply) => {
-      const asset = request.params.asset ? request.params.asset : null;
+      const asset = request.params.asset ? request.params.asset.toString() : null;
 
       const sqlQuery = sqlQueries.statsPrice({ asset });
 

--- a/app/routes/hydradx-ui/v1/stats/tvl.mjs
+++ b/app/routes/hydradx-ui/v1/stats/tvl.mjs
@@ -38,7 +38,7 @@ export default async (fastify, opts) => {
       },
     },
     handler: async (request, reply) => {
-      const asset = request.params.asset ? request.params.asset : null;
+      const asset = request.params.asset ? request.params.asset.toString() : null;
 
       const sqlQuery = sqlQueries.statsTvl({ asset });
 

--- a/app/routes/hydradx-ui/v1/stats/tvl.mjs
+++ b/app/routes/hydradx-ui/v1/stats/tvl.mjs
@@ -19,7 +19,7 @@ export default async (fastify, opts) => {
         type: "object",
         properties: {
           asset: {
-            type: "integer",
+            type: "string",
             description: "Asset (id). Leave empty for all assets.",
           },
         },

--- a/app/routes/hydradx-ui/v1/stats/tvl.mjs
+++ b/app/routes/hydradx-ui/v1/stats/tvl.mjs
@@ -19,7 +19,7 @@ export default async (fastify, opts) => {
         type: "object",
         properties: {
           asset: {
-            type: "string",
+            type: "integer",
             description: "Asset (id). Leave empty for all assets.",
           },
         },
@@ -38,7 +38,10 @@ export default async (fastify, opts) => {
       },
     },
     handler: async (request, reply) => {
-      const asset = request.params.asset ? request.params.asset.toString() : null;
+      const asset =
+        request.params.asset !== undefined && request.params.asset !== null
+          ? request.params.asset.toString()
+          : null;
 
       const sqlQuery = sqlQueries.statsTvl({ asset });
 

--- a/app/routes/hydradx-ui/v1/stats/volume.mjs
+++ b/app/routes/hydradx-ui/v1/stats/volume.mjs
@@ -19,7 +19,7 @@ export default async (fastify, opts) => {
         type: "object",
         properties: {
           asset: {
-            type: "integer",
+            type: "string",
             description: "Asset (id). Leave empty for all assets.",
           },
         },
@@ -66,7 +66,7 @@ export default async (fastify, opts) => {
         type: "object",
         properties: {
           asset: {
-            type: "integer",
+            type: "string",
             description: "Asset (id). Leave empty for all assets.",
           },
         },

--- a/app/routes/hydradx-ui/v1/stats/volume.mjs
+++ b/app/routes/hydradx-ui/v1/stats/volume.mjs
@@ -38,7 +38,7 @@ export default async (fastify, opts) => {
       },
     },
     handler: async (request, reply) => {
-      const asset = request.params.asset ? request.params.asset : null;
+      const asset = request.params.asset ? request.params.asset.toString() : null;
 
       const sqlQuery = sqlQueries.statsVolume({ asset });
 
@@ -85,7 +85,7 @@ export default async (fastify, opts) => {
       },
     },
     handler: async (request, reply) => {
-      const asset = request.params.asset ? request.params.asset : null;
+      const asset = request.params.asset ? request.params.asset.toString() : null;
 
       const sqlQuery = sqlQueries.statsVolumeAlltime({ asset });
 

--- a/app/routes/hydradx-ui/v1/stats/volume.mjs
+++ b/app/routes/hydradx-ui/v1/stats/volume.mjs
@@ -19,7 +19,7 @@ export default async (fastify, opts) => {
         type: "object",
         properties: {
           asset: {
-            type: "string",
+            type: "integer",
             description: "Asset (id). Leave empty for all assets.",
           },
         },
@@ -38,7 +38,10 @@ export default async (fastify, opts) => {
       },
     },
     handler: async (request, reply) => {
-      const asset = request.params.asset ? request.params.asset.toString() : null;
+      const asset =
+        request.params.asset !== undefined && request.params.asset !== null
+          ? request.params.asset.toString()
+          : null;
 
       const sqlQuery = sqlQueries.statsVolume({ asset });
 
@@ -66,7 +69,7 @@ export default async (fastify, opts) => {
         type: "object",
         properties: {
           asset: {
-            type: "string",
+            type: "integer",
             description: "Asset (id). Leave empty for all assets.",
           },
         },
@@ -85,7 +88,10 @@ export default async (fastify, opts) => {
       },
     },
     handler: async (request, reply) => {
-      const asset = request.params.asset ? request.params.asset.toString() : null;
+      const asset =
+        request.params.asset !== undefined && request.params.asset !== null
+          ? request.params.asset.toString()
+          : null;
 
       const sqlQuery = sqlQueries.statsVolumeAlltime({ asset });
 

--- a/queries/hydradx-ui/v1/stats/charts/tvl.sql
+++ b/queries/hydradx-ui/v1/stats/charts/tvl.sql
@@ -46,7 +46,7 @@ ordered_data AS (
     WHERE 
         src.rn = 1
         AND CASE
-            WHEN :asset::integer IS NOT NULL
+            WHEN :asset::text IS NOT NULL
             THEN asset_id = :asset
             ELSE
             true

--- a/queries/hydradx-ui/v1/stats/charts/volume.sql
+++ b/queries/hydradx-ui/v1/stats/charts/volume.sql
@@ -12,7 +12,7 @@ WITH CombinedQuery AS (
   SELECT 
     timestamp::date as "timestamp",
     CASE
-      WHEN :asset::integer IS NOT NULL
+      WHEN :asset::text IS NOT NULL
         THEN round(sum(volume_usd))
       ELSE
         round(sum(volume_usd)/2)
@@ -24,7 +24,7 @@ WITH CombinedQuery AS (
     timestamp between now() - interval '30d' and (current_date::timestamp) - interval '1 microsecond'
     AND
      CASE
-      WHEN :asset::integer IS NOT NULL
+      WHEN :asset::text IS NOT NULL
         THEN asset_id = :asset
       ELSE
         true
@@ -34,7 +34,7 @@ WITH CombinedQuery AS (
   SELECT 
     date_trunc('hour', timestamp) as "timestamp",
     CASE
-      WHEN :asset::integer IS NOT NULL
+      WHEN :asset::text IS NOT NULL
         THEN round(sum(volume_usd))
       ELSE
         round(sum(volume_usd)/2)
@@ -46,7 +46,7 @@ WITH CombinedQuery AS (
     timestamp between now() - interval '24h' and date_trunc('hour', now()) - interval '1 microsecond'
     AND
      CASE
-      WHEN :asset::integer IS NOT NULL
+      WHEN :asset::text IS NOT NULL
         THEN asset_id = :asset
       ELSE
         true

--- a/queries/hydradx-ui/v1/stats/fees.sql
+++ b/queries/hydradx-ui/v1/stats/fees.sql
@@ -18,7 +18,7 @@ WITH fees AS (
          AND name = 'Omnipool.SellExecuted'
          AND
             CASE
-            WHEN :asset::integer IS NOT NULL
+            WHEN :asset::text IS NOT NULL
                 THEN CAST(args ->> 'assetOut' AS numeric) = :asset
             ELSE
                 true
@@ -34,7 +34,7 @@ WITH fees AS (
          AND name = 'Omnipool.BuyExecuted'
          AND
             CASE
-            WHEN :asset::integer IS NOT NULL
+            WHEN :asset::text IS NOT NULL
                 THEN CAST(args ->> 'assetIn' AS numeric) = :asset
             ELSE
                 true

--- a/queries/hydradx-ui/v1/stats/fees.sql
+++ b/queries/hydradx-ui/v1/stats/fees.sql
@@ -81,7 +81,7 @@ tvl AS (
 )
 SELECT 
     round(sum((amount / 10^decimals) * price_usd)::numeric, 2) AS accrued_fees_usd,
-    round(avg((POWER(1 + (COALESCE(ROUND((amount / 10^decimals) * price_usd), 0) * parts) / asset_tvl, parts) - 1)::numeric), 4) AS projected_apy_perc
+    round(avg((POWER(1 + COALESCE((amount / 10^decimals) * price_usd, 0) / asset_tvl, parts) - 1)::numeric), 4) * 100 AS projected_apy_perc
 FROM 
     fees
     JOIN token_metadata tm ON asset_id = tm.id

--- a/queries/hydradx-ui/v1/stats/tvl.sql
+++ b/queries/hydradx-ui/v1/stats/tvl.sql
@@ -16,7 +16,7 @@ FROM
   JOIN omnipool_asset oa ON leb.height = oa.block
   JOIN token_metadata tm ON oa.asset_id = tm.id
 WHERE CASE
-      WHEN :asset::integer IS NOT NULL
+      WHEN :asset::text IS NOT NULL
         THEN asset_id = :asset
       ELSE
         true

--- a/queries/hydradx-ui/v1/stats/volume.sql
+++ b/queries/hydradx-ui/v1/stats/volume.sql
@@ -4,7 +4,7 @@
 
 SELECT 
   CASE
-      WHEN :asset::integer IS NOT NULL
+      WHEN :asset::text IS NOT NULL
       THEN 
         SUM(round(volume_roll_24_usd))
       ELSE
@@ -22,7 +22,7 @@ FROM (
     stats_historical
   WHERE
   CASE
-    WHEN :asset::integer IS NOT NULL
+    WHEN :asset::text IS NOT NULL
       THEN asset_id = :asset
     ELSE
       true

--- a/queries/hydradx-ui/v1/stats/volume_alltime.sql
+++ b/queries/hydradx-ui/v1/stats/volume_alltime.sql
@@ -4,7 +4,7 @@
 
 SELECT 
   CASE
-    WHEN :asset::integer IS NOT NULL THEN 
+    WHEN :asset::text IS NOT NULL THEN 
       round(SUM(volume_omnipool_roll_24_usd))
     ELSE 
       round(SUM(volume_omnipool_roll_24_usd)/2)
@@ -22,7 +22,7 @@ FROM (
     stats_historical
   WHERE 
   CASE
-      WHEN :asset::integer IS NOT NULL
+      WHEN :asset::text IS NOT NULL
         THEN asset_id = :asset
       ELSE
         true


### PR DESCRIPTION
When parameter was defined as integer, 0 would be translated as NULL, returning data for all assets.
e.g. `https://api.hydradx.io/hydradx-ui/v1/stats/volume/0` returns volume for all assets

This is to rollback parameter type to string.

