### PR TITLE
Count 2pool as btc

### DIFF
--- a/queries/coingecko/v1/tickers.sql
+++ b/queries/coingecko/v1/tickers.sql
@@ -199,7 +199,7 @@ listed AS (
   FROM 
     omnipool_asset
   WHERE
-    asset_id <> 100
+    asset_id NOT BETWEEN 100 AND 199
 ), 
 combos AS (
   SELECT 
@@ -250,10 +250,21 @@ omnipool_totals AS (
 ), 
 pair_volumes AS (
   SELECT 
-    REPLACE(asset_in::text, '100', CASE WHEN asset_out = '10' THEN '21' ELSE '10' END) as asset_1,
-    REPLACE(asset_out::text, '100', CASE WHEN asset_in = '10' THEN '21' ELSE '10' END) as asset_2,
-    REPLACE(s.symbol, '4-Pool', CASE WHEN s2.symbol = 'USDT' THEN 'USDC' ELSE 'USDT' END) as asset_1_symbol,
-    REPLACE(s2.symbol, '4-Pool', CASE WHEN s.symbol = 'USDT' THEN 'USDC' ELSE 'USDT' END) as asset_2_symbol,
+    CASE WHEN asset_in = 100 THEN REPLACE(asset_in::text, '100', CASE WHEN asset_out = '10' THEN '21' ELSE '10' END)
+         WHEN asset_in = 101 THEN REPLACE(asset_in::text, '101', CASE WHEN asset_out = '11' THEN '19' ELSE '11' END)
+         ELSE asset_in::text
+    END as asset_1,
+    CASE WHEN asset_out = 100 THEN REPLACE(asset_out::text, '100', CASE WHEN asset_in = '10' THEN '21' ELSE '10' END)
+         WHEN asset_out = 101 THEN REPLACE(asset_out::text, '101', CASE WHEN asset_in = '11' THEN '19' ELSE '11' END)
+         ELSE asset_out::text
+    END as asset_2,
+    CASE WHEN asset_in = 100 THEN REPLACE(s.symbol, '4-Pool', CASE WHEN s2.symbol = 'USDT' THEN 'USDC' ELSE 'USDT' END)
+         WHEN asset_in = 101 THEN REPLACE(s.symbol, '2-Pool', CASE WHEN s2.symbol = 'iBTC' THEN 'WBTC' ELSE 'iBTC' END)
+         ELSE s.symbol
+    END as asset_1_symbol,
+    CASE WHEN asset_out = 100 THEN REPLACE(s2.symbol, '4-Pool', CASE WHEN s.symbol = 'USDT' THEN 'USDC' ELSE 'USDT' END)
+         WHEN asset_out = 101 THEN REPLACE(s2.symbol, '2-Pool', CASE WHEN s.symbol = 'iBTC' THEN 'WBTC' ELSE 'iBTC' END)
+    ELSE s2.symbol END as asset_2_symbol,
     s.price as asset_1_price, 
     s2.price as asset_2_price, 
     amount_in / (10 ^ s.decimals) AS base_volume, 


### PR DESCRIPTION
Coingecko doesn't know 2-Pool ticker. This change will funnel all volumes from 2-Pool into iBTC or WBTC pairs