### PR TITLE
Fix 30d volume on main

### DIFF
--- a/queries/hydration-web/v1/stats/vol30d.sql
+++ b/queries/hydration-web/v1/stats/vol30d.sql
@@ -1,6 +1,6 @@
 -- statsVol30d
 SELECT
-  ROUND(SUM(volume_roll_24_usd)) as volume_usd
+  ROUND(SUM(volume_roll_24_usd)) / 2 as volume_usd
 FROM (
   SELECT 
     symbol,
@@ -8,7 +8,7 @@ FROM (
     volume_roll_24_usd,
     timestamp,
     ROW_NUMBER() OVER (
-      PARTITION BY symbol, timestamp::date
+      PARTITION BY asset_id, timestamp::date
       ORDER BY timestamp DESC
     ) AS rn 
   FROM 


### PR DESCRIPTION
This is to fix double counting of volume - as opposed to individual assets, when taking whole omnipool, only one side of the trade should be counted, not both. Also using asset_id is more precise than symbol which can be in theory duplicated.

IDK about that cross-chain volume, we should probably just hide it, as now it should be the same as volume which looks suss