### PR TITLE
fix: require 2 consecutive failures before alerting on indexer checks

### DIFF
--- a/jobs/monitor_job.mjs
+++ b/jobs/monitor_job.mjs
@@ -27,12 +27,14 @@ const CHECKS = {
     label: "Kril Indexer",
     url: "https://adapters.kril.hydration.cloud/dexscreener/latest-block",
     impact: "DexScreener",
+    minFailures: 2, // a single probe over two proxy hops blips occasionally
     mentions: "<@690220205762543643>",
   },
   orca_indexer: {
     label: "Orca Indexer",
     url: "https://orca-main-aggr-indx.indexer.hydration.cloud/graphql",
     impact: "DefiLlama",
+    minFailures: 2, // a single probe over two proxy hops blips occasionally
     mentions: "<@690220205762543643>",
   },
 };


### PR DESCRIPTION
2026-07-16 08:49:10 UTC: the monitor fired a Discord alert for `orca_indexer` on a single failed probe (`failure 1/1 → ok → error`), recovering on the very next cycle. Server-side telemetry for the same minute shows the orca API healthy (all 5 replicas up 20 h, an independent 60-second probe on the direct hostname green throughout) — the blip was a transient on the probe path (the check crosses two proxy hops: nice indexer-proxy → orca traefik), not an outage.

Sets `minFailures: 2` for `orca_indexer` and `dexscreener_adapter`, mirroring the existing `hydration_web_stats: minFailures: 3` precedent: one transient blip no longer pages, a real outage still alerts on the second consecutive check.