### PR TITLE
fix: serve coingecko tickers from neckwork instead of the wedged indexer

### DIFF
--- a/app/routes/coingecko/v1/tickers.mjs
+++ b/app/routes/coingecko/v1/tickers.mjs
@@ -34,10 +34,14 @@ export default async (fastify, opts) => {
     handler: async (request, reply) => {
       const cacheSetting = CACHE_SETTINGS["coingeckoV1Tickers"];
 
-      // warmed by cache_coingecko_tickers_job
+      // warmed by cache_coingecko_tickers_job. an empty array is never a valid
+      // answer, and the stalled indexer left one behind under this key.
       const cachedResult = await fastify.redis.get(cacheSetting.key);
       if (cachedResult) {
-        return reply.send(JSON.parse(cachedResult));
+        const parsed = JSON.parse(cachedResult);
+        if (Array.isArray(parsed) && parsed.length > 0) {
+          return reply.send(parsed);
+        }
       }
 
       // cache cold or expired: fetch inline rather than answer 503

--- a/app/routes/coingecko/v1/tickers.mjs
+++ b/app/routes/coingecko/v1/tickers.mjs
@@ -1,4 +1,5 @@
 import { CACHE_SETTINGS } from "../../../../variables.mjs";
+import { fetchIncumbentTickers } from "../../../../helpers/coingecko_shape.mjs";
 
 export default async (fastify, opts) => {
   fastify.route({
@@ -31,19 +32,45 @@ export default async (fastify, opts) => {
       },
     },
     handler: async (request, reply) => {
-      let cacheSetting = CACHE_SETTINGS["coingeckoV1Tickers"];
+      const cacheSetting = CACHE_SETTINGS["coingeckoV1Tickers"];
 
-      // Read from cache (populated by cache_coingecko_tickers_job)
+      // warmed by cache_coingecko_tickers_job
       const cachedResult = await fastify.redis.get(cacheSetting.key);
-
       if (cachedResult) {
-        reply.send(JSON.parse(cachedResult));
-      } else {
-        reply.code(503).send({
-          error: "Cache not populated",
-          message: "Please wait for the cache job to populate data",
-        });
+        return reply.send(JSON.parse(cachedResult));
       }
+
+      // cache cold or expired: fetch inline rather than answer 503
+      try {
+        const tickers = await fetchIncumbentTickers();
+        if (tickers.length > 0) {
+          const json = JSON.stringify(tickers);
+          await fastify.redis.set(cacheSetting.key, json);
+          await fastify.redis.expire(
+            cacheSetting.key,
+            cacheSetting.expire_after
+          );
+          await fastify.redis.set(cacheSetting.last_good_key, json);
+          await fastify.redis.expire(
+            cacheSetting.last_good_key,
+            cacheSetting.last_good_expire_after
+          );
+          return reply.send(tickers);
+        }
+        fastify.log.warn("[coingecko] upstream returned 0 tickers");
+      } catch (error) {
+        fastify.log.error(error);
+      }
+
+      const lastGood = await fastify.redis.get(cacheSetting.last_good_key);
+      if (lastGood) {
+        return reply.send(JSON.parse(lastGood));
+      }
+
+      return reply.code(503).send({
+        error: "Tickers unavailable",
+        message: "Upstream returned no data and no cached result is available",
+      });
     },
   });
 };

--- a/app/tests/helpers/coingecko_shape.test.mjs
+++ b/app/tests/helpers/coingecko_shape.test.mjs
@@ -1,0 +1,111 @@
+import { test } from "tap";
+import { toIncumbentTickers } from "../../../helpers/coingecko_shape.mjs";
+
+// two pools of the same pair, plus a single-pool pair
+const upstream = [
+  {
+    ticker_id: "HOLLAR_USDC",
+    base_currency: "HOLLAR",
+    target_currency: "USDC",
+    last_price: 1.5,
+    base_volume: 100,
+    target_volume: 150,
+    pool_id: "stableswap:105",
+    liquidity_in_usd: 1000,
+    high: 1.9,
+    low: 1.4,
+  },
+  {
+    ticker_id: "HOLLAR_USDC",
+    base_currency: "HOLLAR",
+    target_currency: "USDC",
+    last_price: 2.5,
+    base_volume: 300,
+    target_volume: 750,
+    pool_id: "stableswap:110",
+    liquidity_in_usd: 2000,
+    high: 1.8,
+    low: 1.2,
+  },
+  {
+    ticker_id: "DOT_H2O",
+    base_currency: "DOT",
+    target_currency: "H2O",
+    last_price: 6.5,
+    base_volume: 10,
+    target_volume: 65,
+    pool_id: "omnipool",
+    liquidity_in_usd: 500,
+    high: 7,
+    low: 6,
+  },
+];
+
+test("collapses per-pool rows into one row per pair", async (t) => {
+  const out = toIncumbentTickers(upstream);
+
+  t.equal(out.length, 2);
+  t.same(
+    out.map((r) => r.ticker_id),
+    ["DOT_H2O", "HOLLAR_USDC"],
+    "sorted by ticker_id"
+  );
+
+  const hollar = out.find((r) => r.ticker_id === "HOLLAR_USDC");
+  t.equal(hollar.base_volume, 400, "base volume sums across pools");
+  t.equal(hollar.target_volume, 900, "target volume sums across pools");
+  t.equal(hollar.high, 1.9, "high is the max across pools");
+  t.equal(hollar.low, 1.2, "low is the min across pools");
+  t.equal(hollar.last_price, 2.5, "last price comes from the deepest pool");
+});
+
+test("keeps the incumbent field order and pool_id convention", async (t) => {
+  const out = toIncumbentTickers(upstream);
+
+  t.same(Object.keys(out[0]), [
+    "ticker_id",
+    "base_currency",
+    "target_currency",
+    "last_price",
+    "base_volume",
+    "target_volume",
+    "pool_id",
+    "liquidity_in_usd",
+    "high",
+    "low",
+  ]);
+  t.ok(
+    out.every((r) => r.pool_id === r.ticker_id),
+    "pool_id repeats ticker_id"
+  );
+});
+
+test("liquidity_in_usd defaults to the incumbent's hardcoded zero", async (t) => {
+  t.ok(toIncumbentTickers(upstream).every((r) => r.liquidity_in_usd === 0));
+
+  const real = toIncumbentTickers(upstream, { liquidity: "real" });
+  t.equal(
+    real.find((r) => r.ticker_id === "HOLLAR_USDC").liquidity_in_usd,
+    3000,
+    "real mode sums pool depth"
+  );
+});
+
+test("rounds to 12 decimal places like the incumbent query", async (t) => {
+  const out = toIncumbentTickers([
+    { ...upstream[2], last_price: 1 / 3, base_volume: 1 / 3 },
+  ]);
+
+  t.equal(out[0].last_price, 0.333333333333);
+  t.equal(out[0].base_volume, 0.333333333333);
+});
+
+test("guards against a malformed upstream payload", async (t) => {
+  t.same(toIncumbentTickers([]), [], "empty upstream stays empty");
+  t.throws(() => toIncumbentTickers({}), "non-array payload throws");
+  t.same(
+    toIncumbentTickers([{ base_currency: "DOT" }]),
+    [],
+    "rows missing a currency are dropped"
+  );
+});

--- a/clients/neckwork.mjs
+++ b/clients/neckwork.mjs
@@ -1,0 +1,43 @@
+import { neckworkBaseUrl } from "../variables.mjs";
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+const DEFAULT_ATTEMPTS = 3;
+
+// a 4xx will not fix itself on retry; everything below is transient
+const RETRYABLE_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export async function neckworkGet(
+  path,
+  { attempts = DEFAULT_ATTEMPTS, timeoutMs = DEFAULT_TIMEOUT_MS } = {}
+) {
+  const url = `${neckworkBaseUrl()}${path}`;
+  let lastError;
+
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    if (attempt > 0) await sleep(250 * 2 ** (attempt - 1));
+
+    try {
+      const response = await fetch(url, {
+        headers: { accept: "application/json" },
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+
+      if (!response.ok) {
+        const error = new Error(`[neckwork] GET ${path} -> ${response.status}`);
+        error.retryable = RETRYABLE_STATUS.has(response.status);
+        throw error;
+      }
+
+      return await response.json();
+    } catch (error) {
+      if (error.retryable === false) throw error;
+      lastError = error;
+    }
+  }
+
+  throw new Error(
+    `[neckwork] GET ${path} failed after ${attempts} attempts: ${lastError?.message}`
+  );
+}

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -33,6 +33,7 @@ services:
       - DOCKER_RUN=1
       - PORT=3000
       - REDIS_URL=redis://redis:6379
+      - NECKWORK_API_URL=${NECKWORK_API_URL:-https://hydration-api.neckwork.net}
     networks:
       - hydration-net
       - gateway
@@ -86,6 +87,8 @@ services:
       - REDIS_URL=redis://redis:6379
       - JOB_NAME=cache-coingecko-tickers-job
       - CONTINUOUS_JOB=true
+      - JOB_INTERVAL_MS=60000
+      - NECKWORK_API_URL=${NECKWORK_API_URL:-https://hydration-api.neckwork.net}
     secrets:
       - xcm_auth_header
       - pgpassword_db

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -33,7 +33,7 @@ services:
       - DOCKER_RUN=1
       - PORT=3000
       - REDIS_URL=redis://redis:6379
-      - NECKWORK_API_URL=${NECKWORK_API_URL:-https://hydration-api.neckwork.net}
+      - NECKWORK_API_URL=https://hydration-api.neckwork.net
     networks:
       - hydration-net
       - gateway
@@ -88,7 +88,7 @@ services:
       - JOB_NAME=cache-coingecko-tickers-job
       - CONTINUOUS_JOB=true
       - JOB_INTERVAL_MS=60000
-      - NECKWORK_API_URL=${NECKWORK_API_URL:-https://hydration-api.neckwork.net}
+      - NECKWORK_API_URL=https://hydration-api.neckwork.net
     secrets:
       - xcm_auth_header
       - pgpassword_db

--- a/helpers/coingecko_shape.mjs
+++ b/helpers/coingecko_shape.mjs
@@ -1,0 +1,95 @@
+import { neckworkGet } from "../clients/neckwork.mjs";
+import { coingeckoLiquiditySource } from "../variables.mjs";
+
+// neckwork publishes one row per (pool, pair), names the real pool in pool_id
+// and reports real depth. the incumbent tickers.sql published one aggregated
+// row per pair, repeated ticker_id in pool_id and hardcoded liquidity to 0.
+// everything here exists to hand CoinGecko the incumbent's shape unchanged.
+
+const num = (value) =>
+  value === null || value === undefined ? 0 : Number(value);
+
+// incumbent applied ROUND(x, 12) to every numeric column
+function round12(value) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return n;
+  return Number(n.toFixed(12));
+}
+
+// deepest pool wins, pool_id breaks ties so the pick never flaps
+function isDeeper(row, incumbentLead) {
+  if (!incumbentLead) return true;
+  const rowVolume = num(row.base_volume);
+  const leadVolume = num(incumbentLead.base_volume);
+  if (rowVolume !== leadVolume) return rowVolume > leadVolume;
+  return String(row.pool_id) < String(incumbentLead.pool_id);
+}
+
+export function toIncumbentTickers(rows, { liquidity = "incumbent" } = {}) {
+  if (!Array.isArray(rows)) {
+    throw new Error("[coingecko] upstream tickers payload is not an array");
+  }
+
+  const pairs = new Map();
+
+  for (const row of rows) {
+    const base = row?.base_currency;
+    const target = row?.target_currency;
+    if (!base || !target) continue;
+
+    const tickerId = `${base}_${target}`;
+    let pair = pairs.get(tickerId);
+
+    if (!pair) {
+      pair = {
+        ticker_id: tickerId,
+        base_currency: base,
+        target_currency: target,
+        base_volume: 0,
+        target_volume: 0,
+        liquidity_in_usd: 0,
+        high: null,
+        low: null,
+        lead: null,
+      };
+      pairs.set(tickerId, pair);
+    }
+
+    pair.base_volume += num(row.base_volume);
+    pair.target_volume += num(row.target_volume);
+    pair.liquidity_in_usd += num(row.liquidity_in_usd);
+
+    const high = num(row.high);
+    const low = num(row.low);
+    if (pair.high === null || high > pair.high) pair.high = high;
+    if (pair.low === null || low < pair.low) pair.low = low;
+
+    // incumbent's last_price was the pair's most recent fill across every pool.
+    // per-pool rows carry no block, so the deepest pool stands in — it only
+    // decides anything for the three pairs that trade in more than one pool.
+    if (isDeeper(row, pair.lead)) pair.lead = row;
+  }
+
+  return [...pairs.values()]
+    .sort((a, b) =>
+      a.ticker_id > b.ticker_id ? 1 : a.ticker_id < b.ticker_id ? -1 : 0
+    )
+    .map((pair) => ({
+      ticker_id: pair.ticker_id,
+      base_currency: pair.base_currency,
+      target_currency: pair.target_currency,
+      last_price: round12(num(pair.lead?.last_price)),
+      base_volume: round12(pair.base_volume),
+      target_volume: round12(pair.target_volume),
+      pool_id: pair.ticker_id,
+      liquidity_in_usd:
+        liquidity === "real" ? round12(pair.liquidity_in_usd) : 0,
+      high: round12(pair.high),
+      low: round12(pair.low),
+    }));
+}
+
+export async function fetchIncumbentTickers() {
+  const rows = await neckworkGet("/coingecko/v1/tickers");
+  return toIncumbentTickers(rows, { liquidity: coingeckoLiquiditySource() });
+}

--- a/jobs.mjs
+++ b/jobs.mjs
@@ -1,9 +1,14 @@
 import { JOBS } from "./variables.mjs";
 import { cacheCoingeckoTickersJob } from "./jobs/cache_coingecko_tickers_job.mjs";
-import { newSqlClientWithFallback } from "./clients/sql.mjs";
 import { newRedisClient } from "./clients/redis.mjs";
 
-const { JOB_NAME, CONTINUOUS_JOB } = process.env;
+const { JOB_NAME, CONTINUOUS_JOB, JOB_INTERVAL_MS } = process.env;
+
+// the loop used to spin with no delay, which was survivable while every
+// iteration was a slow aggregate query. it is an http fetch now.
+const intervalMs = Number(JOB_INTERVAL_MS ?? 60_000);
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const main = async () => {
   if (!JOB_NAME) {
@@ -37,22 +42,23 @@ async function executeJob(job_name) {
 
   try {
     do {
-      // Fresh SQL client each iteration: tries primary first, then fallback.
-      // This ensures automatic failover between iterations.
-      let sqlClient;
       try {
-        sqlClient = await newSqlClientWithFallback();
         console.log(`Executing ${job_name}..`);
         switch (job_name) {
           case JOBS["cacheCoingeckoTickersJob"]: {
-            await cacheCoingeckoTickersJob(sqlClient, redisClient);
+            const count = await cacheCoingeckoTickersJob(redisClient);
+            console.log(`Executed ${job_name} (${count} tickers)`);
             break;
           }
         }
-        console.log(`Executed ${job_name}`);
-      } finally {
-        if (sqlClient) await sqlClient.end();
+      } catch (err) {
+        // a continuous job must outlive a transient upstream failure; the
+        // cached answer keeps serving until the next iteration succeeds.
+        if (!isContinuousJob()) throw err;
+        console.error(`[jobs] ${job_name} iteration failed: ${err.message}`);
       }
+
+      if (isContinuousJob()) await sleep(intervalMs);
     } while (isContinuousJob());
   } finally {
     await redisClient.disconnect();

--- a/jobs/cache_coingecko_tickers_job.mjs
+++ b/jobs/cache_coingecko_tickers_job.mjs
@@ -1,17 +1,29 @@
-import yesql from "yesql";
-import path from "path";
-import { dirname, CACHE_SETTINGS } from "../variables.mjs";
-import { updateCacheFromSql } from "../helpers/cache_helpers.mjs";
+import { CACHE_SETTINGS } from "../variables.mjs";
+import { updateCache } from "../helpers/cache_helpers.mjs";
+import { fetchIncumbentTickers } from "../helpers/coingecko_shape.mjs";
 
-const sqlQueries = yesql(path.join(dirname(), "queries/coingecko/v1/"), {
-  type: "pg",
-});
+export async function cacheCoingeckoTickersJob(redisClient) {
+  const cacheSetting = CACHE_SETTINGS["coingeckoV1Tickers"];
+  const tickers = await fetchIncumbentTickers();
 
-export async function cacheCoingeckoTickersJob(sqlClient, redisClient) {
-  await updateCacheFromSql(
-    sqlClient,
+  // publishing an empty set is what made the 2026-08-25 outage invisible: the
+  // query fell to zero rows and the cache faithfully served [] for ~42h.
+  if (tickers.length === 0) {
+    console.warn("[coingecko] upstream returned 0 tickers, keeping last cache");
+    return 0;
+  }
+
+  const json = JSON.stringify(tickers);
+
+  await updateCache(redisClient, cacheSetting, json);
+  await updateCache(
     redisClient,
-    CACHE_SETTINGS["coingeckoV1Tickers"],
-    sqlQueries.getTickers()
+    {
+      key: cacheSetting.last_good_key,
+      expire_after: cacheSetting.last_good_expire_after,
+    },
+    json
   );
+
+  return tickers.length;
 }

--- a/variables.mjs
+++ b/variables.mjs
@@ -19,6 +19,14 @@ export const redisUri = () => process.env.REDIS_URL ?? "redis://127.0.0.1:6379";
 
 export const rpcUri = () => "wss://rpc.hydradx.cloud";
 
+export const neckworkBaseUrl = () =>
+  process.env.NECKWORK_API_URL ?? "https://hydration-api.neckwork.net";
+
+// the incumbent tickers query hardcoded liquidity_in_usd to 0. neckwork
+// publishes real depth; "real" passes it through, anything else keeps parity.
+export const coingeckoLiquiditySource = () =>
+  process.env.COINGECKO_LIQUIDITY === "real" ? "real" : "incumbent";
+
 // Primary database configuration
 export const primarySqlHost = () => "91.98.180.149";
 export const primarySqlPort = () => 16201;
@@ -49,6 +57,10 @@ export const CACHE_SETTINGS = {
   coingeckoV1Tickers: {
     key: "coingecko_v1_tickers",
     expire_after: 10 * 60,
+    // survives an upstream outage: a stale ticker set beats an empty one,
+    // which is exactly how the 2026-08-25 outage served [] for ~42h.
+    last_good_key: "coingecko_v1_tickers_last_good",
+    last_good_expire_after: 24 * 60 * 60,
   },
   hydrationWebV1Stats: {
     key: "hydration-web_v1_stats",


### PR DESCRIPTION
`/coingecko/v1/tickers` has been serving `[]` since ~2026-08-25 13:32 UTC. CoinGecko's listing is fully stale — all 46 tickers `is_stale: true`, 24h volume 0.0 BTC. The aggregation-indexer processor stalled, `tickers.sql` filters `block.timestamp > now() - interval '1 day'`, zero blocks in window → empty array, cached and served as if real.

Same URL, same response shape, different backend: `hydration-api.neckwork.net`.

## Shape is preserved exactly

neckwork documents three deliberate deviations from the incumbent; all three are undone here so CoinGecko sees no change:

- one row **per pool** → one row **per pair** (61 → 58 rows); volumes summed, `high`/`low` min-maxed across pools
- `pool_id` back to repeating `ticker_id` (was `stableswap:102` / `omnipool` / `xyk:0x…`)
- `liquidity_in_usd` back to the incumbent's hardcoded `0` — `COINGECKO_LIQUIDITY=real` publishes neckwork's real depth instead
- `ROUND(x, 12)` on every numeric, sorted by `ticker_id`, incumbent field order

Canonicalisation needed no adjustment — verified 0 violations across all 61 upstream rows against the incumbent rule (H2O/GDOT/GETH pinned to target in that precedence, everything else symbol-ordered). Price convention matches too: both use the base/target quantity ratio, confirmed by reading `tickers.sql` and by `neckwork_last_price × coingecko_last ≈ 1.0000` on every non-drifting pair.

## Resilience

The outage was invisible because an empty result was cached and served as data. Now:

- job refuses to publish an empty ticker set, keeps the previous one
- route falls back to last-known-good (24h) when upstream fails, instead of 503
- cold cache fetches inline rather than answering 503

Two bugs fixed in passing: the continuous job loop had **no delay** between iterations (survivable when each was a slow SQL aggregate, a rate-limit problem now it's an HTTP fetch → `JOB_INTERVAL_MS`, default 60s), and a single failed iteration killed the job instead of retrying.

## Known difference: the ticker set

Shape is identical; the row set is not. Against CoinGecko's last-good ingest:

- 33/46 of their known tickers still present
- 29 new ones — the incumbent's hardcoded token-metadata table had been silently dropping these
- 13 absent: `DED_*`/`PINK_*` (not in the on-chain registry neckwork reads), and `DOT_USDC`/`DOT_HOLLAR`/`HDX_HOLLAR` (the incumbent took a cartesian product of each event's boundary inputs×outputs producing direct pairs; neckwork reports per-hop pairs against H2O). Rest are plausibly inactive in the current 24h window.

Reproducing that would mean re-synthesising pairs that never matched a real pool, so it is deliberately not done.

## Testing

5 new unit tests for the adapter. End-to-end against live neckwork: cold 88ms, warm 1ms, byte-identical; upstream-dead and upstream-empty paths both verified to serve last-known-good rather than an empty or error response. Merge arithmetic checked by hand against a frozen snapshot for the 3 multi-pool pairs.

`root.test.mjs` fails, but it fails identically on `main` (wants Redis on :6379) — pre-existing, untouched.