### PR TITLE
fix: serve defillama volume from the firesquid archive

### DIFF
--- a/app/routes/defillama/v1/backfill.mjs
+++ b/app/routes/defillama/v1/backfill.mjs
@@ -21,10 +21,18 @@ async function volumeForDay(redisClient, day) {
   const start = new Date(`${day}T00:00:00.000Z`);
   const end = new Date(start.getTime() + DAY_MS);
   const result = await volumeForRange(redisClient, start, end);
-  const totals = {
-    volume_usd: result?.volumeUsd ?? 0,
-    dailyFees: result?.feesUsd ?? 0,
-  };
+
+  // an archive with no blocks for this day is not the same statement as
+  // "nothing traded". publishing 0 is what wrote phantom zeros into DefiLlama's
+  // series while the old indexer was stalled — and caching it below would have
+  // made that stick for 30 days.
+  if (!result) {
+    const error = new Error(`archive has no blocks for ${day}`);
+    error.noDataDay = day;
+    throw error;
+  }
+
+  const totals = { volume_usd: result.volumeUsd, dailyFees: result.feesUsd };
 
   // only past days are settled; today's number still moves
   if (end.getTime() <= Date.now()) {
@@ -101,6 +109,15 @@ export default async (fastify, opts) => {
 
         return reply.send([{ volume_usd: volumeUsd, dailyFees }]);
       } catch (error) {
+        if (error.noDataDay) {
+          fastify.log.warn(
+            `[defillama] archive has no data for ${error.noDataDay}`
+          );
+          return reply.code(503).send({
+            error: "Range not indexed",
+            message: `The archive has no data for ${error.noDataDay}; refusing to report zero volume`,
+          });
+        }
         fastify.log.error(error);
         return reply
           .code(500)

--- a/app/routes/defillama/v1/backfill.mjs
+++ b/app/routes/defillama/v1/backfill.mjs
@@ -1,51 +1,37 @@
-import { gql, request as gqlRequest } from "graphql-request";
+import { CACHE_SETTINGS } from "../../../../variables.mjs";
+import { volumeForRange } from "../../../../helpers/defillama_source.mjs";
 
-const GRAPHQL_ENDPOINT =
-  "https://orca-sh-prod-pool-02.orca.hydration.cloud/graphql";
+const DAY_MS = 24 * 60 * 60 * 1000;
 
-async function fetchVolumeForPeriod(startIsoString, endIsoString) {
-  const timeout = (ms) =>
-    new Promise((_, reject) =>
-      setTimeout(() => reject(new Error("Request timeout")), ms)
-    );
+// each uncached day costs a full sweep of that day's swap events, so a range has
+// to be bounded. matches the limit the reference implementation advertises.
+const MAX_DAYS = 62;
 
-  const fetchData = async () => {
-    const data = await gqlRequest(
-      GRAPHQL_ENDPOINT,
-      gql`
-        query GetVolumeForPeriod(
-          $startIsoString: String!
-          $endIsoString: String!
-        ) {
-          platformTotalVolumesByPeriod(
-            filter: {
-              startIsoString: $startIsoString
-              endIsoString: $endIsoString
-            }
-          ) {
-            nodes {
-              paraBlockHeight
-              omnipoolFeeVolNorm
-              omnipoolVolNorm
-              stableswapFeeVolNorm
-              stableswapVolNorm
-              totalVolNorm
-              xykpoolFeeVolNorm
-              xykpoolVolNorm
-            }
-          }
-        }
-      `,
-      {
-        startIsoString,
-        endIsoString,
-      }
-    );
+function dayKey(date) {
+  return date.toISOString().slice(0, 10);
+}
 
-    return data.platformTotalVolumesByPeriod.nodes[0];
+async function volumeForDay(redisClient, day) {
+  const cacheSetting = CACHE_SETTINGS["defillamaV1Backfill"];
+  const key = `${cacheSetting.key}:${day}`;
+
+  const cached = await redisClient.get(key);
+  if (cached) return JSON.parse(cached);
+
+  const start = new Date(`${day}T00:00:00.000Z`);
+  const end = new Date(start.getTime() + DAY_MS);
+  const result = await volumeForRange(redisClient, start, end);
+  const totals = {
+    volume_usd: result?.volumeUsd ?? 0,
+    dailyFees: result?.feesUsd ?? 0,
   };
 
-  return Promise.race([fetchData(), timeout(10000)]);
+  // only past days are settled; today's number still moves
+  if (end.getTime() <= Date.now()) {
+    await redisClient.set(key, JSON.stringify(totals));
+    await redisClient.expire(key, cacheSetting.expire_after);
+  }
+  return totals;
 }
 
 export default async (fastify, opts) => {
@@ -76,18 +62,13 @@ export default async (fastify, opts) => {
       try {
         const { startDate, endDate } = request.query;
 
-        // Validate dates
         if (!startDate || !endDate) {
           return reply.code(400).send({
             error: "Both startDate and endDate are required",
           });
         }
 
-        // Convert to ISO strings (assuming UTC timezone and midnight)
-        const startIsoString = `${startDate}T00:00:00.000Z`;
-
-        // Validate date format
-        const startDateObj = new Date(startIsoString);
+        const startDateObj = new Date(`${startDate}T00:00:00.000Z`);
         const endDateObj = new Date(`${endDate}T00:00:00.000Z`);
 
         if (isNaN(startDateObj.getTime()) || isNaN(endDateObj.getTime())) {
@@ -102,45 +83,28 @@ export default async (fastify, opts) => {
           });
         }
 
-        // Make endDate inclusive by adding 1 day to the end ISO string
-        const endDatePlusOne = new Date(
-          endDateObj.getTime() + 24 * 60 * 60 * 1000
-        );
-        const endIsoString = endDatePlusOne.toISOString();
-
-        // Fetch from GraphQL
-        const volumeData = await fetchVolumeForPeriod(
-          startIsoString,
-          endIsoString
-        );
-
-        if (!volumeData) {
-          return reply.send([
-            {
-              volume_usd: 0,
-              dailyFees: 0,
-            },
-          ]);
+        const days = Math.round((endDateObj - startDateObj) / DAY_MS) + 1; // endDate inclusive
+        if (days > MAX_DAYS) {
+          return reply.code(400).send({
+            error: `Date range too large. Maximum ${MAX_DAYS} days per request`,
+          });
         }
 
-        // Calculate total fees (sum of all fee volumes)
-        const totalFees =
-          parseFloat(volumeData.omnipoolFeeVolNorm) +
-          parseFloat(volumeData.stableswapFeeVolNorm) +
-          parseFloat(volumeData.xykpoolFeeVolNorm);
+        let volumeUsd = 0;
+        let dailyFees = 0;
+        for (let i = 0; i < days; i++) {
+          const day = dayKey(new Date(startDateObj.getTime() + i * DAY_MS));
+          const totals = await volumeForDay(fastify.redis, day);
+          volumeUsd += totals.volume_usd;
+          dailyFees += totals.dailyFees;
+        }
 
-        // Format response in defillama expected format
-        const response = [
-          {
-            volume_usd: parseFloat(volumeData.totalVolNorm),
-            dailyFees: totalFees,
-          },
-        ];
-
-        reply.send(response);
+        return reply.send([{ volume_usd: volumeUsd, dailyFees }]);
       } catch (error) {
         fastify.log.error(error);
-        reply.code(500).send({ error: "Failed to fetch backfill volume data" });
+        return reply
+          .code(500)
+          .send({ error: "Failed to fetch backfill volume data" });
       }
     },
   });

--- a/app/routes/defillama/v1/volume.mjs
+++ b/app/routes/defillama/v1/volume.mjs
@@ -1,7 +1,5 @@
 import { CACHE_SETTINGS } from "../../../../variables.mjs";
-import { volumeForRange } from "../../../../helpers/defillama_source.mjs";
-
-const DAY_MS = 24 * 60 * 60 * 1000;
+import { refreshVolume24h } from "../../../../helpers/defillama_source.mjs";
 
 export default async (fastify, opts) => {
   fastify.route({
@@ -29,30 +27,26 @@ export default async (fastify, opts) => {
         return reply.send(JSON.parse(cachedResult));
       }
 
+      // cold sweep on a request path is slow, so the warm job normally gets
+      // here first; this is the fallback when the cache has lapsed.
       try {
-        const now = new Date();
-        const result = await volumeForRange(
-          fastify.redis,
-          new Date(now.getTime() - DAY_MS),
-          null
-        );
-
-        if (!result) {
-          return reply.code(503).send({
-            error: "Volume unavailable",
-            message: "Archive returned no blocks for the last 24h",
-          });
-        }
-
-        const response = [{ volume_usd: result.volumeUsd }];
-        await fastify.redis.set(cacheSetting.key, JSON.stringify(response));
-        await fastify.redis.expire(cacheSetting.key, cacheSetting.expire_after);
-
-        return reply.send(response);
+        const response = await refreshVolume24h(fastify.redis);
+        if (response) return reply.send(response);
+        fastify.log.warn("[defillama] archive returned no blocks for 24h");
       } catch (error) {
         fastify.log.error(error);
-        return reply.code(500).send({ error: "Failed to fetch volume data" });
       }
+
+      const lastGood = await fastify.redis.get(cacheSetting.last_good_key);
+      if (lastGood) {
+        return reply.send(JSON.parse(lastGood));
+      }
+
+      return reply.code(503).send({
+        error: "Volume unavailable",
+        message:
+          "The archive returned no data and no cached result is available",
+      });
     },
   });
 };

--- a/app/routes/defillama/v1/volume.mjs
+++ b/app/routes/defillama/v1/volume.mjs
@@ -1,32 +1,7 @@
-import { gql, request as gqlRequest } from "graphql-request";
 import { CACHE_SETTINGS } from "../../../../variables.mjs";
+import { volumeForRange } from "../../../../helpers/defillama_source.mjs";
 
-const GRAPHQL_ENDPOINT =
-  "https://orca-main-aggr-indx.indexer.hydration.cloud/graphql";
-
-async function fetchVolumeFromGraphQL() {
-  const data = await gqlRequest(
-    GRAPHQL_ENDPOINT,
-    gql`
-      {
-        platformTotalVolumesByPeriod(filter: { period: _24H_ }) {
-          nodes {
-            totalVolNorm
-            omnipoolVolNorm
-            omnipoolFeeVolNorm
-            stableswapVolNorm
-            stableswapFeeVolNorm
-            xykpoolVolNorm
-            xykpoolFeeVolNorm
-            paraBlockHeight
-          }
-        }
-      }
-    `
-  );
-
-  return data.platformTotalVolumesByPeriod.nodes[0];
-}
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 export default async (fastify, opts) => {
   fastify.route({
@@ -46,35 +21,37 @@ export default async (fastify, opts) => {
       },
     },
     handler: async (request, reply) => {
-      try {
-        // Use a cache key that doesn't depend on asset since we're getting platform-wide data
-        let cacheSetting = { ...CACHE_SETTINGS["defillamaV1Volume"] };
-        cacheSetting.key = "defillama_v1_volume_graphql_array_format";
+      // platform-wide figure, so the asset param does not change the answer
+      const cacheSetting = CACHE_SETTINGS["defillamaV1Volume"];
 
-        // Check cache first
-        const cachedResult = await fastify.redis.get(cacheSetting.key);
-        if (cachedResult) {
-          return reply.send(JSON.parse(cachedResult));
+      const cachedResult = await fastify.redis.get(cacheSetting.key);
+      if (cachedResult) {
+        return reply.send(JSON.parse(cachedResult));
+      }
+
+      try {
+        const now = new Date();
+        const result = await volumeForRange(
+          fastify.redis,
+          new Date(now.getTime() - DAY_MS),
+          null
+        );
+
+        if (!result) {
+          return reply.code(503).send({
+            error: "Volume unavailable",
+            message: "Archive returned no blocks for the last 24h",
+          });
         }
 
-        // Fetch from GraphQL
-        const volumeData = await fetchVolumeFromGraphQL();
-
-        // Format response to maintain original format - array with single object
-        const response = [
-          {
-            volume_usd: parseFloat(volumeData.totalVolNorm),
-          },
-        ];
-
-        // Cache the result using the correct expire_after setting
+        const response = [{ volume_usd: result.volumeUsd }];
         await fastify.redis.set(cacheSetting.key, JSON.stringify(response));
         await fastify.redis.expire(cacheSetting.key, cacheSetting.expire_after);
 
-        reply.send(response);
+        return reply.send(response);
       } catch (error) {
         fastify.log.error(error);
-        reply.code(500).send({ error: "Failed to fetch volume data" });
+        return reply.code(500).send({ error: "Failed to fetch volume data" });
       }
     },
   });

--- a/app/tests/helpers/defillama_volume.test.mjs
+++ b/app/tests/helpers/defillama_volume.test.mjs
@@ -1,0 +1,139 @@
+import { test } from "tap";
+import {
+  aggregateByDay,
+  totalsOf,
+} from "../../../helpers/defillama_volume.mjs";
+
+// 10 = USDT and 2 = DAI are hard $1 anchors in the price graph, so any fill with
+// one of them on a side has a determined USD value. 1 = LRNA, the omnipool hub.
+const USDT = 10;
+const DAI = 2;
+const LRNA = 1;
+const SHARE = 999;
+
+function fill(overrides) {
+  return {
+    day: "2026-08-20",
+    hour: "2026-08-20T12",
+    filler: "XYK",
+    inAsset: USDT,
+    inAmount: 100,
+    outAsset: DAI,
+    outAmount: 100,
+    inIsPoolShare: false,
+    outIsPoolShare: false,
+    fees: [],
+    ...overrides,
+  };
+}
+
+const volumeOf = (fills) => totalsOf(aggregateByDay(fills)).volumeUsd;
+const feesOf = (fills) => totalsOf(aggregateByDay(fills)).feesUsd;
+
+test("omnipool counts one leg — the non-LRNA side", async (t) => {
+  // 50 LRNA -> 100 USDT, so LRNA derives to $2 and both legs are worth $100
+  t.equal(
+    volumeOf([fill({ filler: "Omnipool", inAsset: LRNA, inAmount: 50 })]),
+    100,
+    "LRNA on the input side -> output leg counted"
+  );
+
+  t.equal(
+    volumeOf([fill({ filler: "Omnipool", outAsset: LRNA, outAmount: 50 })]),
+    100,
+    "LRNA on the output side -> input leg counted"
+  );
+});
+
+test("an omnipool route counts twice, once per hop", async (t) => {
+  // A->LRNA then LRNA->B is how the router reports a single omnipool swap
+  const hops = [
+    fill({ filler: "Omnipool", outAsset: LRNA, outAmount: 50 }),
+    fill({ filler: "Omnipool", inAsset: LRNA, inAmount: 50 }),
+  ];
+  t.equal(volumeOf(hops), 200, "$100 of trade reported as $200 of volume");
+});
+
+test("stableswap counts both legs, or one against its share token", async (t) => {
+  t.equal(
+    volumeOf([fill({ filler: "Stableswap" })]),
+    200,
+    "both sides are pool assets -> both legs"
+  );
+
+  t.equal(
+    volumeOf([
+      fill({ filler: "Stableswap", outAsset: SHARE, outIsPoolShare: true }),
+    ]),
+    100,
+    "share token on the output -> input leg only"
+  );
+
+  t.equal(
+    volumeOf([
+      fill({ filler: "Stableswap", inAsset: SHARE, inIsPoolShare: true }),
+    ]),
+    100,
+    "share token on the input -> output leg only"
+  );
+});
+
+test("xyk counts both legs", async (t) => {
+  t.equal(volumeOf([fill({ filler: "XYK" })]), 200);
+});
+
+test("aave, otc and hsm fills are not volume", async (t) => {
+  for (const filler of ["Aave", "OTC", "HSM"]) {
+    t.same(
+      aggregateByDay([fill({ filler })]),
+      {},
+      `${filler} contributes nothing, not even a day bucket`
+    );
+  }
+});
+
+test("omnipool fees charged in LRNA are excluded", async (t) => {
+  const base = { filler: "Omnipool", inAsset: LRNA, inAmount: 50 };
+
+  t.equal(
+    feesOf([fill({ ...base, fees: [{ asset: LRNA, amount: 5 }] })]),
+    0,
+    "LRNA is the hub, not a pool asset"
+  );
+
+  t.equal(
+    feesOf([fill({ ...base, fees: [{ asset: USDT, amount: 5 }] })]),
+    5,
+    "a fee in a real pool asset counts"
+  );
+});
+
+test("stableswap and xyk fees count whatever they are charged in", async (t) => {
+  t.equal(
+    feesOf([fill({ filler: "XYK", fees: [{ asset: USDT, amount: 3 }] })]),
+    3
+  );
+  t.equal(
+    feesOf([fill({ filler: "Stableswap", fees: [{ asset: DAI, amount: 2 }] })]),
+    2
+  );
+});
+
+test("volume is bucketed per UTC day", async (t) => {
+  const byDay = aggregateByDay([
+    fill({ day: "2026-08-20", hour: "2026-08-20T23" }),
+    fill({ day: "2026-08-21", hour: "2026-08-21T00" }),
+    fill({ day: "2026-08-21", hour: "2026-08-21T01" }),
+  ]);
+
+  t.same(Object.keys(byDay).sort(), ["2026-08-20", "2026-08-21"]);
+  t.equal(byDay["2026-08-20"].volumeUsd, 200);
+  t.equal(byDay["2026-08-21"].volumeUsd, 400);
+  t.equal(totalsOf(byDay).volumeUsd, 600, "totals sum every day");
+});
+
+test("a fill with no priceable side is dropped, not counted as zero", async (t) => {
+  // two assets that never touch an anchor cannot be valued
+  const orphan = fill({ inAsset: 8001, outAsset: 8002 });
+  t.same(aggregateByDay([orphan]), {});
+});

--- a/clients/firesquid.mjs
+++ b/clients/firesquid.mjs
@@ -1,5 +1,9 @@
 import { gql, request as gqlRequest } from "graphql-request";
-import { firesquidEndpoints, firesquidChunkBlocks } from "../variables.mjs";
+import {
+  firesquidEndpoints,
+  firesquidChunkBlocks,
+  firesquidRowLimit,
+} from "../variables.mjs";
 
 // the firesquid archive keeps raw `block` + `event` rows for the whole chain and
 // is fed straight off an rpc, so it does not stall when the aggregation indexer
@@ -77,10 +81,11 @@ export async function firstBlockAtOrAfter(date) {
 // `event.name` is unindexed there, but the block-height predicate is not.
 export async function fetchSwapEvents(fromHeight, toHeight, onBatch) {
   const chunk = firesquidChunkBlocks();
+  const limit = firesquidRowLimit();
   for (let from = fromHeight; from < toHeight; from += chunk) {
     const to = Math.min(from + chunk, toHeight);
-    const data = await query(SWAPS_IN_RANGE, { from, to, limit: 10000 });
-    if (data.events.length >= 10000) {
+    const data = await query(SWAPS_IN_RANGE, { from, to, limit });
+    if (data.events.length >= limit) {
       throw new Error(
         `[firesquid] chunk ${from}-${to} hit the row limit; lower firesquidChunkBlocks`
       );

--- a/clients/firesquid.mjs
+++ b/clients/firesquid.mjs
@@ -1,0 +1,90 @@
+import { gql, request as gqlRequest } from "graphql-request";
+import { firesquidEndpoints, firesquidChunkBlocks } from "../variables.mjs";
+
+// the firesquid archive keeps raw `block` + `event` rows for the whole chain and
+// is fed straight off an rpc, so it does not stall when the aggregation indexer
+// does. reads go through the archive's own substrate-explorer.
+
+const LATEST_BLOCK = gql`
+  {
+    blocks(orderBy: height_DESC, limit: 1) {
+      height
+      timestamp
+    }
+  }
+`;
+
+const FIRST_BLOCK_AT = gql`
+  query FirstBlockAt($ts: DateTime!) {
+    blocks(where: { timestamp_gte: $ts }, orderBy: height_ASC, limit: 1) {
+      height
+      timestamp
+    }
+  }
+`;
+
+const SWAPS_IN_RANGE = gql`
+  query SwapsInRange($from: Int!, $to: Int!, $limit: Int!) {
+    events(
+      where: {
+        name_eq: "Broadcast.Swapped3"
+        block: { height_gte: $from, height_lt: $to }
+      }
+      orderBy: id_ASC
+      limit: $limit
+    ) {
+      args
+      block {
+        height
+        timestamp
+      }
+    }
+  }
+`;
+
+// tries each configured archive in turn; they are independent hosts indexing the
+// same chain, so any healthy one is as good as another.
+async function query(document, variables) {
+  let lastError;
+  for (const endpoint of firesquidEndpoints()) {
+    try {
+      return await gqlRequest(endpoint, document, variables);
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw new Error(
+    `[firesquid] all archives failed. Last error: ${lastError?.message}`
+  );
+}
+
+export async function latestBlock() {
+  const data = await query(LATEST_BLOCK);
+  const block = data.blocks[0];
+  if (!block) throw new Error("[firesquid] archive returned no blocks");
+  return { height: block.height, timestamp: new Date(block.timestamp) };
+}
+
+export async function firstBlockAtOrAfter(date) {
+  const data = await query(FIRST_BLOCK_AT, { ts: date.toISOString() });
+  const block = data.blocks[0];
+  return block
+    ? { height: block.height, timestamp: new Date(block.timestamp) }
+    : null;
+}
+
+// height-chunked so every query stays inside the archive's statement timeout;
+// `event.name` is unindexed there, but the block-height predicate is not.
+export async function fetchSwapEvents(fromHeight, toHeight, onBatch) {
+  const chunk = firesquidChunkBlocks();
+  for (let from = fromHeight; from < toHeight; from += chunk) {
+    const to = Math.min(from + chunk, toHeight);
+    const data = await query(SWAPS_IN_RANGE, { from, to, limit: 10000 });
+    if (data.events.length >= 10000) {
+      throw new Error(
+        `[firesquid] chunk ${from}-${to} hit the row limit; lower firesquidChunkBlocks`
+      );
+    }
+    onBatch(data.events);
+  }
+}

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -102,6 +102,26 @@ services:
         limits:
           memory: 256M
 
+  # separate service because a jobs container runs exactly one JOB_NAME. the
+  # archive sweep is ~15s cold, so this keeps DefiLlama off that path entirely.
+  jobs-defillama:
+    <<: *api-common
+    image: ${IMAGE_JOBS:-greenjay/hydration-api-jobs:latest}
+    environment:
+      - DOCKER_RUN=1
+      - REDIS_URL=redis://redis:6379
+      - JOB_NAME=cache-defillama-volume-job
+      - CONTINUOUS_JOB=true
+      - JOB_INTERVAL_MS=300000
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: on-failure
+        delay: 10s
+      resources:
+        limits:
+          memory: 512M
+
   monitor:
     <<: *api-common
     image: ${IMAGE_MONITOR:-greenjay/hydration-api-monitor:latest}

--- a/helpers/asset_registry.mjs
+++ b/helpers/asset_registry.mjs
@@ -1,0 +1,39 @@
+import { newRpcClient } from "../clients/rpc.mjs";
+import { CACHE_SETTINGS } from "../variables.mjs";
+
+// decimals and asset type straight from the on-chain registry, so nothing here
+// has to be kept in a hand-maintained table.
+async function readRegistry() {
+  const api = await newRpcClient();
+  try {
+    const entries = await api.query.assetRegistry.assets.entries();
+    const meta = {};
+    for (const [key, value] of entries) {
+      const asset = value.unwrapOr(null);
+      if (!asset) continue;
+      const json = asset.toJSON();
+      const type =
+        typeof json.assetType === "string"
+          ? json.assetType
+          : Object.keys(json.assetType ?? {})[0];
+      meta[key.args[0].toString()] = {
+        decimals: json.decimals ?? null,
+        isPoolShare: type === "StableSwap",
+      };
+    }
+    return meta;
+  } finally {
+    await api.disconnect();
+  }
+}
+
+export async function getAssetRegistry(redisClient) {
+  const cacheSetting = CACHE_SETTINGS["assetRegistry"];
+  const cached = await redisClient.get(cacheSetting.key);
+  if (cached) return JSON.parse(cached);
+
+  const meta = await readRegistry();
+  await redisClient.set(cacheSetting.key, JSON.stringify(meta));
+  await redisClient.expire(cacheSetting.key, cacheSetting.expire_after);
+  return meta;
+}

--- a/helpers/defillama_source.mjs
+++ b/helpers/defillama_source.mjs
@@ -1,3 +1,4 @@
+import { CACHE_SETTINGS } from "../variables.mjs";
 import {
   fetchSwapEvents,
   firstBlockAtOrAfter,
@@ -48,4 +49,32 @@ export async function volumeForRange(redisClient, start, end) {
     fills: fills.length,
     head: range.head,
   };
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// computes the rolling 24h figure and writes both cache slots. shared by the
+// route and the warm job so a cold sweep is never paid on a request path.
+// returns null when the archive has no blocks for the window — never a zero.
+export async function refreshVolume24h(redisClient) {
+  const cacheSetting = CACHE_SETTINGS["defillamaV1Volume"];
+  const result = await volumeForRange(
+    redisClient,
+    new Date(Date.now() - DAY_MS),
+    null
+  );
+  if (!result) return null;
+
+  const response = [{ volume_usd: result.volumeUsd }];
+  const json = JSON.stringify(response);
+
+  await redisClient.set(cacheSetting.key, json);
+  await redisClient.expire(cacheSetting.key, cacheSetting.expire_after);
+  await redisClient.set(cacheSetting.last_good_key, json);
+  await redisClient.expire(
+    cacheSetting.last_good_key,
+    cacheSetting.last_good_expire_after
+  );
+
+  return response;
 }

--- a/helpers/defillama_source.mjs
+++ b/helpers/defillama_source.mjs
@@ -1,0 +1,51 @@
+import {
+  fetchSwapEvents,
+  firstBlockAtOrAfter,
+  latestBlock,
+} from "../clients/firesquid.mjs";
+import { getAssetRegistry } from "./asset_registry.mjs";
+import {
+  aggregateByDay,
+  parseSwapEvents,
+  totalsOf,
+} from "./defillama_volume.mjs";
+
+// resolves a [start, end) instant range onto archive block heights. end is
+// exclusive; a null end means "up to the archive head".
+async function heightRange(start, end) {
+  const head = await latestBlock();
+  const first = await firstBlockAtOrAfter(start);
+  if (!first) return null;
+
+  let toHeight = head.height + 1;
+  if (end != null && end < head.timestamp) {
+    const last = await firstBlockAtOrAfter(end);
+    if (last) toHeight = last.height;
+  }
+  if (toHeight <= first.height) return null;
+
+  return { fromHeight: first.height, toHeight, head };
+}
+
+async function collectFills(fromHeight, toHeight, registry) {
+  const fills = [];
+  await fetchSwapEvents(fromHeight, toHeight, (events) => {
+    for (const fill of parseSwapEvents(events, registry)) fills.push(fill);
+  });
+  return fills;
+}
+
+export async function volumeForRange(redisClient, start, end) {
+  const registry = await getAssetRegistry(redisClient);
+  const range = await heightRange(start, end);
+  if (!range) return null;
+
+  const fills = await collectFills(range.fromHeight, range.toHeight, registry);
+  const byDay = aggregateByDay(fills);
+  return {
+    ...totalsOf(byDay),
+    byDay,
+    fills: fills.length,
+    head: range.head,
+  };
+}

--- a/helpers/defillama_volume.mjs
+++ b/helpers/defillama_volume.mjs
@@ -1,0 +1,249 @@
+// Reproduces the counting convention of the aggregation indexer that used to
+// serve these endpoints, so the series DefiLlama already ingests does not step.
+// That indexer accumulated volume per *pool asset*, which works out as:
+//
+//   omnipool   -> one leg per fill, the non-LRNA side. the router emits a
+//                 separate fill for A->LRNA and LRNA->B, so an omnipool trade is
+//                 counted twice; a routed trade is counted once per hop.
+//   stableswap -> both legs when both are pool assets, one leg when the other
+//                 side is the pool's own share token.
+//   xyk        -> both legs.
+//   aave / otc / hsm fills are not counted at all.
+//
+// Fees follow the same idea: omnipool fees charged in LRNA are not counted
+// (LRNA is the hub, not a pool asset); stableswap and xyk fees are.
+//
+// Validated against the incumbent over 14 days (2026-08-03..09, 2026-08-17..23):
+// volume within 0.49% every day, mean ratio 1.0003; fees mean ratio 1.017.
+
+const LRNA_ASSET_ID = 1;
+const COUNTED_FILLERS = new Set(["Omnipool", "Stableswap", "XYK"]);
+
+// hard usd-pegged assets used to anchor the price graph. deliberately a small
+// set — the graph derives everything else, so losing one of these is harmless.
+const USD_ANCHORS = [10, 22, 21, 7, 23, 1002, 1003, 2, 18];
+
+// both legs of a fill are worth the same modulo fees. a bigger gap than this
+// means one leg's derived price is junk (thin long-tail pairs), so we fall back
+// to whichever leg sits nearer an anchor.
+const PRICE_DISAGREEMENT_GUARD = 3;
+
+function median(values) {
+  const sorted = values.slice().sort((a, b) => a - b);
+  return sorted[sorted.length >> 1];
+}
+
+// keeps every fill, including the pool types that are not counted: aave fills
+// are the atoken<->underlying bridges that anchor those assets in the price
+// graph, so they have to be there even though their volume is not counted.
+export function parseSwapEvents(events, registry) {
+  const fills = [];
+  for (const event of events) {
+    const args = event.args;
+    const filler = args.fillerType?.__kind;
+    if (!filler) continue;
+
+    const input = args.inputs?.[0];
+    const output = args.outputs?.[0];
+    if (!input || !output) continue;
+
+    const inMeta = registry[String(input.asset)];
+    const outMeta = registry[String(output.asset)];
+    // external assets carry no decimals on chain; they only ever show up in
+    // long-tail xyk pairs, so skipping them costs a rounding error.
+    if (inMeta?.decimals == null || outMeta?.decimals == null) continue;
+
+    const timestamp = event.block.timestamp;
+    fills.push({
+      day: timestamp.slice(0, 10),
+      hour: timestamp.slice(0, 13),
+      filler,
+      inAsset: input.asset,
+      inAmount: Number(input.amount) / 10 ** inMeta.decimals,
+      outAsset: output.asset,
+      outAmount: Number(output.amount) / 10 ** outMeta.decimals,
+      inIsPoolShare: inMeta.isPoolShare === true,
+      outIsPoolShare: outMeta.isPoolShare === true,
+      fees: (args.fees ?? [])
+        .map((fee) => {
+          const feeMeta = registry[String(fee.asset)];
+          if (feeMeta?.decimals == null) return null;
+          return {
+            asset: fee.asset,
+            amount: Number(fee.amount) / 10 ** feeMeta.decimals,
+          };
+        })
+        .filter(Boolean),
+    });
+  }
+  return fills;
+}
+
+// value conservation gives price_b = price_a * amountA / amountB for every fill,
+// so a breadth-first walk out from the $1 anchors prices the whole asset graph
+// off the swaps themselves. no external price feed needed.
+function derivePrices(fills) {
+  const ratios = new Map();
+  const neighbours = new Map();
+
+  const addEdge = (a, b, ratio) => {
+    if (!(ratio > 0) || !Number.isFinite(ratio)) return;
+    const key = `${a}|${b}`;
+    if (!ratios.has(key)) ratios.set(key, []);
+    ratios.get(key).push(ratio);
+    if (!neighbours.has(a)) neighbours.set(a, new Set());
+    neighbours.get(a).add(b);
+  };
+
+  for (const fill of fills) {
+    if (!(fill.inAmount > 0) || !(fill.outAmount > 0)) continue;
+    addEdge(fill.inAsset, fill.outAsset, fill.inAmount / fill.outAmount);
+    addEdge(fill.outAsset, fill.inAsset, fill.outAmount / fill.inAmount);
+  }
+
+  const prices = new Map();
+  const hops = new Map();
+  for (const anchor of USD_ANCHORS) {
+    prices.set(anchor, 1);
+    hops.set(anchor, 0);
+  }
+
+  let frontier = [...prices.keys()];
+  for (let hop = 0; hop < 6 && frontier.length > 0; hop++) {
+    const discovered = new Map();
+    for (const from of frontier) {
+      for (const to of neighbours.get(from) ?? []) {
+        if (prices.has(to)) continue;
+        const observed = ratios.get(`${from}|${to}`);
+        if (!observed?.length) continue;
+        const candidate = prices.get(from) * median(observed);
+        if (!(candidate > 0) || !Number.isFinite(candidate)) continue;
+        // prefer the best-observed edge into this asset
+        const existing = discovered.get(to);
+        if (!existing || observed.length > existing.samples) {
+          discovered.set(to, { price: candidate, samples: observed.length });
+        }
+      }
+    }
+    for (const [asset, found] of discovered) {
+      prices.set(asset, found.price);
+      hops.set(asset, hop + 1);
+    }
+    frontier = [...discovered.keys()];
+  }
+
+  return { prices, hops };
+}
+
+function groupBy(fills, keyFn) {
+  const groups = new Map();
+  for (const fill of fills) {
+    const key = keyFn(fill);
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(fill);
+  }
+  return groups;
+}
+
+// prices move intraday, so value each fill at its own hour where possible and
+// fall back to coarser windows when an asset barely traded.
+function buildPriceLookup(fills) {
+  const hourly = new Map();
+  for (const [hour, group] of groupBy(fills, (f) => f.hour)) {
+    hourly.set(hour, derivePrices(group));
+  }
+  const daily = new Map();
+  for (const [day, group] of groupBy(fills, (f) => f.day)) {
+    daily.set(day, derivePrices(group));
+  }
+  const overall = derivePrices(fills);
+
+  return (fill, asset) => {
+    for (const table of [hourly.get(fill.hour), daily.get(fill.day), overall]) {
+      const price = table?.prices.get(asset);
+      if (price != null) {
+        return {
+          price,
+          hops: table.hops.get(asset) ?? Number.MAX_SAFE_INTEGER,
+        };
+      }
+    }
+    return null;
+  };
+}
+
+function legValues(fill, lookup) {
+  const inSide = lookup(fill, fill.inAsset);
+  const outSide = lookup(fill, fill.outAsset);
+  if (!inSide && !outSide) return null;
+
+  let inValue = inSide ? fill.inAmount * inSide.price : null;
+  let outValue = outSide ? fill.outAmount * outSide.price : null;
+  if (inValue == null) inValue = outValue;
+  if (outValue == null) outValue = inValue;
+
+  if (
+    inValue > 0 &&
+    outValue > 0 &&
+    Math.max(inValue, outValue) / Math.min(inValue, outValue) >
+      PRICE_DISAGREEMENT_GUARD
+  ) {
+    const trustIn = !outSide || (inSide && inSide.hops <= outSide.hops);
+    if (trustIn) outValue = inValue;
+    else inValue = outValue;
+  }
+
+  if (!Number.isFinite(inValue) || !Number.isFinite(outValue)) return null;
+  return { inValue, outValue };
+}
+
+// returns { "YYYY-MM-DD": { volumeUsd, feesUsd } }
+export function aggregateByDay(fills) {
+  const lookup = buildPriceLookup(fills);
+  const byDay = {};
+
+  for (const fill of fills) {
+    if (!COUNTED_FILLERS.has(fill.filler)) continue;
+    const values = legValues(fill, lookup);
+    if (!values) continue;
+    const { inValue, outValue } = values;
+
+    const bucket = (byDay[fill.day] ??= { volumeUsd: 0, feesUsd: 0 });
+    const priceOf = (asset) => lookup(fill, asset)?.price ?? null;
+
+    if (fill.filler === "Omnipool") {
+      bucket.volumeUsd += fill.inAsset === LRNA_ASSET_ID ? outValue : inValue;
+      for (const fee of fill.fees) {
+        if (fee.asset === LRNA_ASSET_ID) continue;
+        const price = priceOf(fee.asset);
+        if (price != null) bucket.feesUsd += fee.amount * price;
+      }
+      continue;
+    }
+
+    if (fill.filler === "Stableswap") {
+      if (fill.inIsPoolShare) bucket.volumeUsd += outValue;
+      else if (fill.outIsPoolShare) bucket.volumeUsd += inValue;
+      else bucket.volumeUsd += inValue + outValue;
+    } else {
+      bucket.volumeUsd += inValue + outValue;
+    }
+
+    for (const fee of fill.fees) {
+      const price = priceOf(fee.asset);
+      if (price != null) bucket.feesUsd += fee.amount * price;
+    }
+  }
+
+  return byDay;
+}
+
+export function totalsOf(byDay) {
+  let volumeUsd = 0;
+  let feesUsd = 0;
+  for (const day of Object.values(byDay)) {
+    volumeUsd += day.volumeUsd;
+    feesUsd += day.feesUsd;
+  }
+  return { volumeUsd, feesUsd };
+}

--- a/jobs.mjs
+++ b/jobs.mjs
@@ -1,5 +1,6 @@
 import { JOBS } from "./variables.mjs";
 import { cacheCoingeckoTickersJob } from "./jobs/cache_coingecko_tickers_job.mjs";
+import { cacheDefillamaVolumeJob } from "./jobs/cache_defillama_volume_job.mjs";
 import { newRedisClient } from "./clients/redis.mjs";
 
 const { JOB_NAME, CONTINUOUS_JOB, JOB_INTERVAL_MS } = process.env;
@@ -48,6 +49,11 @@ async function executeJob(job_name) {
           case JOBS["cacheCoingeckoTickersJob"]: {
             const count = await cacheCoingeckoTickersJob(redisClient);
             console.log(`Executed ${job_name} (${count} tickers)`);
+            break;
+          }
+          case JOBS["cacheDefillamaVolumeJob"]: {
+            const volume = await cacheDefillamaVolumeJob(redisClient);
+            console.log(`Executed ${job_name} (volume_usd ${volume})`);
             break;
           }
         }

--- a/jobs/cache_defillama_volume_job.mjs
+++ b/jobs/cache_defillama_volume_job.mjs
@@ -1,0 +1,15 @@
+import { refreshVolume24h } from "../helpers/defillama_source.mjs";
+
+// a cold 24h sweep of the archive takes ~15s, which is long enough for a
+// partner's http client to give up. keeping the cache warm means DefiLlama
+// only ever reads a value that was already computed.
+export async function cacheDefillamaVolumeJob(redisClient) {
+  const response = await refreshVolume24h(redisClient);
+
+  if (!response) {
+    console.warn("[defillama] archive returned no blocks, keeping last cache");
+    return null;
+  }
+
+  return response[0].volume_usd;
+}

--- a/variables.mjs
+++ b/variables.mjs
@@ -42,9 +42,14 @@ export const firesquidEndpoints = () => [
   "https://hydradx-explorer.shellfish.hydration.cloud/graphql",
 ];
 
-// blocks per archive query. keeps each one well inside the archive's statement
-// timeout, since `event.name` is unindexed there.
-export const firesquidChunkBlocks = () => 1000;
+// blocks per archive query. the archive is round-trip bound rather than scan
+// bound over a height range, so bigger chunks are much faster; the ceiling is
+// firesquidRowLimit, which a chunk must never reach.
+export const firesquidChunkBlocks = () => 5000;
+
+// peak observed density is ~1.4 swaps/block, so this leaves ~3x headroom over a
+// full chunk. a chunk that reaches it throws rather than silently truncating.
+export const firesquidRowLimit = () => 20000;
 
 export const xcmAuthHeader = () =>
   readSecret("xcm_auth_header", "XCM_AUTH_HEADER");

--- a/variables.mjs
+++ b/variables.mjs
@@ -35,6 +35,17 @@ export const fallbackSqlPass = () =>
   readSecret("pgpassword_db_fallback", "PGPASSWORD_DB_FALLBACK");
 export const fallbackSqlDatabase = () => "aggregator_indexer";
 
+// firesquid archives: raw block/event mirrors of the chain, fed straight off an
+// rpc. independent hosts, tried in order.
+export const firesquidEndpoints = () => [
+  "https://hydradx-explorer.play.hydration.cloud/graphql",
+  "https://hydradx-explorer.shellfish.hydration.cloud/graphql",
+];
+
+// blocks per archive query. keeps each one well inside the archive's statement
+// timeout, since `event.name` is unindexed there.
+export const firesquidChunkBlocks = () => 1000;
+
 export const xcmAuthHeader = () =>
   readSecret("xcm_auth_header", "XCM_AUTH_HEADER");
 
@@ -61,5 +72,15 @@ export const CACHE_SETTINGS = {
   defillamaV1Volume: {
     key: "defillama_v1_volume",
     expire_after: 10 * 60,
+  },
+  // per-day results keyed by date. past days never change, so they are kept
+  // long enough that a backfill sweep only pays for each day once.
+  defillamaV1Backfill: {
+    key: "defillama_v1_backfill_day",
+    expire_after: 30 * 24 * 60 * 60,
+  },
+  assetRegistry: {
+    key: "asset_registry",
+    expire_after: 6 * 60 * 60,
   },
 };

--- a/variables.mjs
+++ b/variables.mjs
@@ -67,6 +67,7 @@ export const discordWebhookUrl = () =>
 
 export const JOBS = {
   cacheCoingeckoTickersJob: "cache-coingecko-tickers-job",
+  cacheDefillamaVolumeJob: "cache-defillama-volume-job",
 };
 
 export const CACHE_SETTINGS = {
@@ -89,6 +90,9 @@ export const CACHE_SETTINGS = {
   defillamaV1Volume: {
     key: "defillama_v1_volume",
     expire_after: 10 * 60,
+    // survives an archive outage: a stale figure beats a made-up zero
+    last_good_key: "defillama_v1_volume_last_good",
+    last_good_expire_after: 24 * 60 * 60,
   },
   // per-day results keyed by date. past days never change, so they are kept
   // long enough that a backfill sweep only pays for each day once.


### PR DESCRIPTION
`/defillama/v1/volume` returns 500 and `/defillama/v1/backfill` returns **HTTP 200 with `volume_usd: 0`** for every day since 2026-08-25. Both aggregation indexers stalled around block 13,762,692; `orca-sh-prod-pool-02` is ~3 days behind chain tip. DefiLlama has been ingesting zeros, which is worse than the 500 because it looks like data.

This reads volume from the **firesquid archive** instead — independent of the aggregation indexer, which is why it didn't stall.

## Reproducing the incumbent, not replacing it

Moving to neckwork was the obvious fix but its number is 2–3.4× lower by design (it single-counts each trade), which would put a cliff in DefiLlama's chart. So the incumbent's convention was decoded from raw `Broadcast.Swapped3` instead. It accumulates **per pool asset**:

- **Omnipool** → one leg, the non-LRNA side. Every Omnipool fill has LRNA on exactly one side, so a routed A→B is two fills and counts **twice**
- **Stableswap** → both legs when both are pool assets, one when the counterparty is the pool's own share token
- **XYK** → both legs
- **AAVE / OTC / HSM** → not counted
- Fees follow the same rule, so LRNA-denominated Omnipool fees are excluded

Pricing needs **no external feed**: value conservation gives `price_b = price_a × amtA/amtB` per fill, so a BFS out from a small set of $1-pegged anchors prices the whole graph off the swaps themselves, per hour with daily/global fallback. Decimals and the share-token flag come from the on-chain `assetRegistry` (Redis-cached 6h), retiring the hand-maintained token table.

## Calibration

14 days vs the incumbent — `2026-08-17..23` fixed the convention, **`2026-08-03..09` was held out**:

| | |
|---|---|
| 14-day mean ratio | **1.0003** |
| worst single-day deviation | **0.49%** |
| held-out week via `/backfill` | **16,961,590.91** vs incumbent **16,965,632.38** → **0.024%** |
| fees | mean 1.017, worst 3.4% |

Recovered days the incumbent lost: 08-25 → 2,420,893 and 08-26 → 3,203,216, where production returns `0`. Both cross-check against neckwork at 3.0× and 3.21×, inside the documented 2–3.4× band.

Do **not** calibrate against 2026-08-24 — the incumbent's 2,028,901.20 is a partial day, it stalled ~38% through.

## Never publish a zero we did not measure

`volumeForDay` previously did `result?.volumeUsd ?? 0`, so an archive with no blocks for a day produced a real-looking `0` — and cached it for 30 days. That is the same failure that put phantom zeros into DefiLlama's series. Now:

- no data for a day → `503 {error: "Range not indexed"}` naming the day, and **nothing is cached**
- `/volume` falls back to a 24h last-known-good before erroring
- a genuinely flat period still returns `0`; only *absence* is treated as no data

Supersedes `defillama-no-phantom-zeros`, which fixed the same bug against the old GraphQL source. That branch should be closed unmerged.

## Cold path

A 24h sweep is ~15s cold, long enough for a partner's HTTP client to give up. Added `cache-defillama-volume-job` on the existing jobs pattern plus a `jobs-defillama` service (a jobs container runs exactly one `JOB_NAME`), refreshing every 5 min against a 10-min TTL. Measured: warm job 14.2s, `/volume` then serves in **1.3ms**.

`event.name` is confirmed unindexed — a `LIMIT 2` top-N on name alone times out at 12s — but the height-windowed shape is round-trip bound, not scan bound (10k blocks → 1.2–1.6s), so **no index or materialised rollup is needed**.

## Testing

9 unit tests pinning the counting convention, including the counter-intuitive "an omnipool route counts twice" — the rule most likely to be broken by a well-meaning later edit. End-to-end verified: held-out week reproduces identically after the refactor, no-data day 503s and is not cached, archive-dead serves last-known-good, archive-dead with no cache 503s.

`root.test.mjs` fails, but identically on `main` (wants Redis on :6379) — pre-existing.

## Needs confirming before this is relied on

- **`MAX_DAYS = 62` cap on `/backfill`** is a behaviour change — the incumbent was uncapped because its indexer pre-aggregated. A 7-day range takes ~90s cold, so uncapped would be minutes. Worth checking DefiLlama chunks its requests.
- The data path is `hydradx-explorer.play.hydration.cloud` (shellfish as fallback), a public GraphQL explorer with no SLA. Direct firesquid Postgres has no published port on either swarm and `nice` sits outside them, so a repoint needs a deploy.