### PR TITLE
defillama: expose per-pool fee split on /backfill and /volume

### DIFF
--- a/app/routes/defillama/v1/backfill.mjs
+++ b/app/routes/defillama/v1/backfill.mjs
@@ -32,7 +32,17 @@ async function volumeForDay(redisClient, day) {
     throw error;
   }
 
-  const totals = { volume_usd: result.volumeUsd, dailyFees: result.feesUsd };
+  const totals = {
+    volume_usd: result.volumeUsd,
+    dailyFees: result.feesUsd,
+    // per-pool-type fee split so consumers (DefiLlama) can reproduce the
+    // incumbent's fee/revenue breakdown; omnipool excludes LRNA-charged fees.
+    fees: {
+      xyk: result.feesUsdByPool.XYK,
+      stableswap: result.feesUsdByPool.Stableswap,
+      omnipool: result.feesUsdByPool.Omnipool,
+    },
+  };
 
   // only past days are settled; today's number still moves
   if (end.getTime() <= Date.now()) {

--- a/app/tests/helpers/defillama_volume.test.mjs
+++ b/app/tests/helpers/defillama_volume.test.mjs
@@ -119,6 +119,26 @@ test("stableswap and xyk fees count whatever they are charged in", async (t) => 
   );
 });
 
+test("fees are split per pool type, summing to the total", async (t) => {
+  const byPool = (fills) => totalsOf(aggregateByDay(fills)).feesUsdByPool;
+  const split = byPool([
+    fill({ filler: "XYK", fees: [{ asset: USDT, amount: 3 }] }),
+    fill({ filler: "Stableswap", fees: [{ asset: DAI, amount: 2 }] }),
+    fill({
+      filler: "Omnipool",
+      inAsset: LRNA,
+      inAmount: 50,
+      fees: [
+        { asset: USDT, amount: 5 },
+        { asset: LRNA, amount: 99 }, // hub fee — excluded everywhere
+      ],
+    }),
+  ]);
+  t.equal(split.XYK, 3, "xyk fees bucketed to xyk");
+  t.equal(split.Stableswap, 2, "stableswap fees bucketed to stableswap");
+  t.equal(split.Omnipool, 5, "omnipool fees exclude the LRNA-charged leg");
+});
+
 test("volume is bucketed per UTC day", async (t) => {
   const byDay = aggregateByDay([
     fill({ day: "2026-08-20", hour: "2026-08-20T23" }),

--- a/helpers/defillama_source.mjs
+++ b/helpers/defillama_source.mjs
@@ -65,7 +65,17 @@ export async function refreshVolume24h(redisClient) {
   );
   if (!result) return null;
 
-  const response = [{ volume_usd: result.volumeUsd }];
+  const response = [
+    {
+      volume_usd: result.volumeUsd,
+      dailyFees: result.feesUsd,
+      fees: {
+        xyk: result.feesUsdByPool.XYK,
+        stableswap: result.feesUsdByPool.Stableswap,
+        omnipool: result.feesUsdByPool.Omnipool,
+      },
+    },
+  ];
   const json = JSON.stringify(response);
 
   await redisClient.set(cacheSetting.key, json);

--- a/helpers/defillama_volume.mjs
+++ b/helpers/defillama_volume.mjs
@@ -197,7 +197,7 @@ function legValues(fill, lookup) {
   return { inValue, outValue };
 }
 
-// returns { "YYYY-MM-DD": { volumeUsd, feesUsd } }
+// returns { "YYYY-MM-DD": { volumeUsd, feesUsd, feesUsdByPool: { Omnipool, Stableswap, XYK } } }
 export function aggregateByDay(fills) {
   const lookup = buildPriceLookup(fills);
   const byDay = {};
@@ -208,7 +208,11 @@ export function aggregateByDay(fills) {
     if (!values) continue;
     const { inValue, outValue } = values;
 
-    const bucket = (byDay[fill.day] ??= { volumeUsd: 0, feesUsd: 0 });
+    const bucket = (byDay[fill.day] ??= {
+      volumeUsd: 0,
+      feesUsd: 0,
+      feesUsdByPool: { Omnipool: 0, Stableswap: 0, XYK: 0 },
+    });
     const priceOf = (asset) => lookup(fill, asset)?.price ?? null;
 
     if (fill.filler === "Omnipool") {
@@ -216,7 +220,11 @@ export function aggregateByDay(fills) {
       for (const fee of fill.fees) {
         if (fee.asset === LRNA_ASSET_ID) continue;
         const price = priceOf(fee.asset);
-        if (price != null) bucket.feesUsd += fee.amount * price;
+        if (price != null) {
+          const value = fee.amount * price;
+          bucket.feesUsd += value;
+          bucket.feesUsdByPool.Omnipool += value;
+        }
       }
       continue;
     }
@@ -231,7 +239,12 @@ export function aggregateByDay(fills) {
 
     for (const fee of fill.fees) {
       const price = priceOf(fee.asset);
-      if (price != null) bucket.feesUsd += fee.amount * price;
+      if (price != null) {
+        const value = fee.amount * price;
+        bucket.feesUsd += value;
+        // fill.filler is "Stableswap" or "XYK" here (Omnipool returns above)
+        bucket.feesUsdByPool[fill.filler] += value;
+      }
     }
   }
 
@@ -241,9 +254,15 @@ export function aggregateByDay(fills) {
 export function totalsOf(byDay) {
   let volumeUsd = 0;
   let feesUsd = 0;
+  const feesUsdByPool = { Omnipool: 0, Stableswap: 0, XYK: 0 };
   for (const day of Object.values(byDay)) {
     volumeUsd += day.volumeUsd;
     feesUsd += day.feesUsd;
+    if (day.feesUsdByPool) {
+      feesUsdByPool.Omnipool += day.feesUsdByPool.Omnipool;
+      feesUsdByPool.Stableswap += day.feesUsdByPool.Stableswap;
+      feesUsdByPool.XYK += day.feesUsdByPool.XYK;
+    }
   }
-  return { volumeUsd, feesUsd };
+  return { volumeUsd, feesUsd, feesUsdByPool };
 }


### PR DESCRIPTION
Adds a per-pool-type fee breakdown to the DeFiLlama endpoints so consumers can reproduce the incumbent's fee/revenue split instead of a single flattened total.

## What
- `aggregateByDay` / `totalsOf` (`helpers/defillama_volume.mjs`) now track fees per pool type in `feesUsdByPool: { Omnipool, Stableswap, XYK }`, keyed off each fill's `filler`. Omnipool still excludes LRNA-charged (hub) fees.
- `/defillama/v1/backfill` and `/defillama/v1/volume` now return `fees: { xyk, stableswap, omnipool }` alongside the existing `volume_usd` / `dailyFees`.

## Why
The DeFiLlama Hydration adapter (`DefiLlama/dimension-adapters: dexs/hydration-dex`) currently reads `xykpoolFeeVolNorm` / `stableswapFeeVolNorm` / `omnipoolFeeVolNorm` from the (now-stalled) aggregation indexer to build its Fees/Revenue/SupplySide/Holders/Protocol breakdown. To repoint that adapter onto this REST API without losing the breakdown, the endpoints need to expose the same per-pool split. This is the prerequisite for the dimension-adapters repoint PR.

## Compatibility
Purely additive — `volume_usd`, `dailyFees`, and `feesUsd` are unchanged; existing consumers are unaffected. Existing tests still hold; added a test asserting the split sums to the total and that Omnipool excludes the LRNA leg.

Note: cached backfill days written before this deploy carry no `fees` field; flush `defillama_v1_backfill_day:*` after deploy so they recompute with the breakdown.