### PR TITLE
defillama: include per-pool fees in /backfill response

### DIFF
--- a/app/routes/defillama/v1/backfill.mjs
+++ b/app/routes/defillama/v1/backfill.mjs
@@ -110,14 +110,20 @@ export default async (fastify, opts) => {
 
         let volumeUsd = 0;
         let dailyFees = 0;
+        const fees = { xyk: 0, stableswap: 0, omnipool: 0 };
         for (let i = 0; i < days; i++) {
           const day = dayKey(new Date(startDateObj.getTime() + i * DAY_MS));
           const totals = await volumeForDay(fastify.redis, day);
           volumeUsd += totals.volume_usd;
           dailyFees += totals.dailyFees;
+          if (totals.fees) {
+            fees.xyk += totals.fees.xyk;
+            fees.stableswap += totals.fees.stableswap;
+            fees.omnipool += totals.fees.omnipool;
+          }
         }
 
-        return reply.send([{ volume_usd: volumeUsd, dailyFees }]);
+        return reply.send([{ volume_usd: volumeUsd, dailyFees, fees }]);
       } catch (error) {
         if (error.noDataDay) {
           fastify.log.warn(


### PR DESCRIPTION
Follow-up to #53. That PR added `feesUsdByPool` to per-day compute + the per-day backfill cache and to /volume, but the `/backfill` route handler aggregates days into `[{ volume_usd, dailyFees }]` and **dropped the per-pool `fees`** — so /backfill still returned no breakdown (per-day cache had it, response didn't). This sums `fees.{xyk,stableswap,omnipool}` across the range and includes it, matching /volume. Additive; verified per-day cache already carries the field in prod.