### PR TITLE
fix: refuse defillama backfill for days we cannot serve correctly

### DIFF
--- a/app/routes/defillama/v1/backfill.mjs
+++ b/app/routes/defillama/v1/backfill.mjs
@@ -1,4 +1,7 @@
-import { CACHE_SETTINGS } from "../../../../variables.mjs";
+import {
+  CACHE_SETTINGS,
+  defillamaTrustedFrom,
+} from "../../../../variables.mjs";
 import { volumeForRange } from "../../../../helpers/defillama_source.mjs";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -98,6 +101,17 @@ export default async (fastify, opts) => {
         if (startDateObj > endDateObj) {
           return reply.code(400).send({
             error: "startDate must be before or equal to endDate",
+          });
+        }
+
+        // refusing beats answering with numbers we know are wrong: a consumer
+        // re-running a backfill over the early era would replace correct
+        // history with zeros or 40%-off figures.
+        const trustedFrom = defillamaTrustedFrom();
+        if (startDate < trustedFrom) {
+          return reply.code(400).send({
+            error: "Range predates reliable coverage",
+            message: `This endpoint only serves days from ${trustedFrom} onward; ${startDate} is earlier. Before that the archive lacks the unified swap event and the derived figures diverge from the historical series`,
           });
         }
 

--- a/app/tests/routes/defillama_backfill_guard.test.mjs
+++ b/app/tests/routes/defillama_backfill_guard.test.mjs
@@ -1,0 +1,42 @@
+import { test } from "tap";
+import { defillamaTrustedFrom } from "../../../variables.mjs";
+
+// The guard is a plain lexical date comparison on YYYY-MM-DD, which is what the
+// route does. These pin the boundary itself rather than standing up fastify,
+// which would need a live archive and a redis.
+const before = (day) => day < defillamaTrustedFrom();
+
+test("the trust boundary defaults to the measured one", async (t) => {
+  t.equal(defillamaTrustedFrom(), "2026-02-01");
+});
+
+test("days before the boundary are refused", async (t) => {
+  // no Broadcast.Swapped3 in the archive at all -> a sweep would report 0
+  t.ok(before("2024-04-28"), "DefiLlama adapter start date");
+  t.ok(before("2024-08-20"), "the 2024 fees gap");
+  t.ok(before("2025-05-20"), "last day with no swap events");
+
+  // archive has events, but the derived figures run up to 40% off
+  t.ok(before("2025-05-21"), "first day with events, still untrusted");
+  t.ok(before("2025-09-01"), "measured ratio 1.206");
+  t.ok(before("2026-01-01"), "measured ratio 1.176");
+});
+
+test("days from the boundary onward are served", async (t) => {
+  t.notOk(before("2026-02-01"), "measured ratio 1.002");
+  t.notOk(before("2026-02-15"), "measured ratio 0.997");
+  t.notOk(before("2026-07-05"), "a fillable gap day");
+  t.notOk(before("2026-07-09"), "a fillable gap day");
+  t.notOk(before("2026-08-27"), "current data");
+});
+
+test("the boundary is overridable for a deliberate backfill", async (t) => {
+  const original = process.env.DEFILLAMA_TRUSTED_FROM;
+  process.env.DEFILLAMA_TRUSTED_FROM = "2025-05-21";
+  t.equal(defillamaTrustedFrom(), "2025-05-21");
+  t.notOk("2025-06-01" < defillamaTrustedFrom(), "earlier era opens up");
+  t.ok("2025-05-20" < defillamaTrustedFrom(), "the zero era stays shut");
+
+  if (original === undefined) delete process.env.DEFILLAMA_TRUSTED_FROM;
+  else process.env.DEFILLAMA_TRUSTED_FROM = original;
+});

--- a/variables.mjs
+++ b/variables.mjs
@@ -55,6 +55,18 @@ export const firesquidEndpoints = () => [
 // firesquidRowLimit, which a chunk must never reach.
 export const firesquidChunkBlocks = () => 5000;
 
+// earliest day this endpoint will answer for. two hard limits sit behind it:
+// the archive carries no `Broadcast.Swapped3` before 2025-05-21 (swaps were
+// emitted under the older event shape, so a sweep finds nothing and would
+// report a real-looking 0), and through 2026-01 the derived figures disagree
+// with the incumbent series by up to 40% — the price graph is reconstructed
+// from the swaps themselves and is thin that far back. Measured 2026-08-28
+// against DefiLlama's own stored series: 2026-01-01 ratio 1.176, 2026-02-01
+// 1.002, 2026-02-15 0.997. Serving the earlier era would silently overwrite
+// a consumer's correct history with worse numbers, so refuse it instead.
+export const defillamaTrustedFrom = () =>
+  process.env.DEFILLAMA_TRUSTED_FROM ?? "2026-02-01";
+
 // peak observed density is ~1.4 swaps/block, so this leaves ~3x headroom over a
 // full chunk. a chunk that reaches it throws rather than silently truncating.
 export const firesquidRowLimit = () => 20000;


### PR DESCRIPTION
`/defillama/v1/backfill` currently answers for **any** date, including years where the number it returns is wrong. Since DefiLlama's adapter now reads this endpoint, a historical re-run would overwrite their correct history with ours.

## Two distinct failure regions, both silent

**Before 2025-05-21 — returns a real-looking `0`.** The archive carries no `Broadcast.Swapped3` that far back (swaps were emitted under the older event shape), so a sweep finds nothing and reports zero volume with HTTP 200. Bisected:

```
2025-05-20  ->  volume_usd: 0
2025-05-21  ->  volume_usd: 5,084,795
```

**2025-05-21 through 2026-01 — returns numbers up to 40% off.** Measured against DefiLlama's own stored series:

| date | ours ÷ DefiLlama |
|---|---|
| 2025-05-22 | 1.341 |
| 2025-05-25 | 1.402 |
| 2025-09-01 | 1.206 |
| 2025-11-01 | 1.072 |
| 2026-01-01 | 1.176 |
| **2026-02-01** | **1.002** |
| 2026-02-15 | 0.997 |
| 2026-05-01 | 1.000 |
| 2026-08-15 | 0.999 |

The divergence is erratic rather than a constant factor, consistent with the price graph being reconstructed from the swaps themselves and being thin that far back — not a counting-convention difference.

## Change

Refuse any range starting before `DEFILLAMA_TRUSTED_FROM` (default `2026-02-01`) with `400 {error: "Range predates reliable coverage"}` naming the boundary and why.

Refusing is the safe answer here. DefiLlama holds **correct** data for 2024-04-28 onward, ingested from the old indexer; the risk is not that we lack it, it is that we would replace it with something worse. A 400 leaves their history untouched.

The boundary is env-overridable so a deliberate, supervised backfill can still open the 2025 era if someone wants it.

## Relationship to the existing guard

The no-data guard added in #52 catches "archive has no blocks for this day" and 503s. It does not fire here, because the archive *does* have those blocks — they just contain swap events in the pre-unification format. Same failure class, different boundary.

## Testing

4 tests pinning the boundary, the refused era (including DefiLlama's `start: '2024-04-28'` and the 2024-08 fees gap), the served era (including the three fillable July gap days), and the env override. Verified end-to-end: 2024-04-28 / 2024-08-20 / 2025-05-20 / 2025-09-01 / 2026-01-01 all 400; 2026-02-01 / 07-05 / 07-09 / 07-10 all serve real figures.

## Known gaps in DefiLlama's series, for context

| dimension | gap | fillable from here? |
|---|---|---|
| volume | 2026-07-09 – 07-10 | yes — 2,494,454.07 and 1,482,495.72 |
| fees + revenue | 2026-07-05 | yes — 985.23 (xyk 16.69 / ss 196.49 / omni 772.06) |
| fees + revenue | 2024-08-20 – 08-22 | no, and now correctly refused |

08-25/26/27 are already filled and correct.