### PR TITLE
hydration-web/stats + lending/caps: source from neckwork

### DIFF
--- a/app/routes/hydration-web/v1/stats.mjs
+++ b/app/routes/hydration-web/v1/stats.mjs
@@ -1,10 +1,9 @@
-import { gql, request as gqlRequest } from "graphql-request";
-import { CACHE_SETTINGS, xcmAuthHeader } from "../../../../variables.mjs";
+import { CACHE_SETTINGS } from "../../../../variables.mjs";
+import { neckworkGet } from "../../../../clients/neckwork.mjs";
 
-const ORCA_GRAPHQL_ENDPOINT =
-  "https://orca-main-aggr-indx.indexer.hydration.cloud/graphql";
-const XCM_API_ENDPOINT = "https://api.ocelloids.net/query/xcm";
-
+// neckwork serves this shape natively off the live indexer, replacing the
+// retired orca aggregation-indexer GraphQL (+ the ocelloids XCM call, whose
+// figure neckwork now folds into xcm_vol_30d).
 export default async (fastify, opts) => {
   fastify.route({
     url: "/stats",
@@ -27,170 +26,30 @@ export default async (fastify, opts) => {
       },
     },
     handler: async (request, reply) => {
-      request.log.info("Starting stats handler");
+      const cacheSetting = CACHE_SETTINGS["hydrationWebV1Stats"];
 
       try {
-        const cacheSetting = CACHE_SETTINGS["hydrationWebV1Stats"];
         const cachedResult = await fastify.redis.get(cacheSetting.key);
         if (cachedResult) {
-          request.log.info("Returning cached stats");
           return reply.send(JSON.parse(cachedResult));
         }
 
-        const [
-          omnipoolAssetsData,
-          xykPoolsData,
-          stableAssetsData,
-          accountsData,
-          tvlData,
-          volumeData,
-        ] = await Promise.all([
-          gqlRequest(
-            ORCA_GRAPHQL_ENDPOINT,
-            gql`
-              {
-                omnipoolAssets {
-                  nodes {
-                    assetId
-                  }
-                  totalCount
-                }
-              }
-            `
-          ),
-          gqlRequest(
-            ORCA_GRAPHQL_ENDPOINT,
-            gql`
-              {
-                xykpools {
-                  nodes {
-                    assetAId
-                    assetBId
-                  }
-                }
-              }
-            `
-          ),
-          gqlRequest(
-            ORCA_GRAPHQL_ENDPOINT,
-            gql`
-              {
-                stableswapAssets {
-                  nodes {
-                    assetId
-                  }
-                }
-              }
-            `
-          ),
-          gqlRequest(
-            ORCA_GRAPHQL_ENDPOINT,
-            gql`
-              {
-                accounts {
-                  totalCount
-                }
-              }
-            `
-          ),
-          gqlRequest(
-            ORCA_GRAPHQL_ENDPOINT,
-            gql`
-              {
-                platformTotalTvl {
-                  nodes {
-                    totalTvlDecoratedNorm
-                  }
-                }
-              }
-            `
-          ),
-          gqlRequest(
-            ORCA_GRAPHQL_ENDPOINT,
-            gql`
-              {
-                platformTotalVolumesByPeriod(filter: { period: _30D_ }) {
-                  nodes {
-                    totalVolNorm
-                  }
-                }
-              }
-            `
-          ),
-        ]);
-
-        const omnipoolIds = new Set(
-          omnipoolAssetsData.omnipoolAssets.nodes.map((n) => n.assetId)
-        );
-        const xykAssetIds = new Set();
-        xykPoolsData.xykpools.nodes.forEach(({ assetAId, assetBId }) => {
-          xykAssetIds.add(assetAId);
-          xykAssetIds.add(assetBId);
-        });
-        const stableAssetIds = new Set(
-          stableAssetsData.stableswapAssets.nodes.map((n) => n.assetId)
-        );
-
-        const allTradableAssets = new Set([
-          ...omnipoolIds,
-          ...xykAssetIds,
-          ...stableAssetIds,
-        ]);
-        const assetsCount = allTradableAssets.size;
-        const accountsCount = accountsData.accounts.totalCount;
-
-        const vol30d = Number(
-          volumeData.platformTotalVolumesByPeriod.nodes[0]?.totalVolNorm || 0
-        );
-
-        let xcmVol30d = 0;
-        try {
-          const controller = new AbortController();
-          const timeoutId = setTimeout(() => controller.abort(), 30000);
-
-          const xcmRes = await fetch(XCM_API_ENDPOINT, {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              Authorization: `Bearer ${xcmAuthHeader()}`,
-            },
-            body: JSON.stringify({
-              args: {
-                op: "transfers_by_network",
-                criteria: { timeframe: "1 months" },
-              },
-            }),
-            signal: controller.signal,
-          });
-
-          clearTimeout(timeoutId);
-          const json = await xcmRes.json();
-          const hydration = json.items?.find(
-            (x) => x.network === "urn:ocn:polkadot:2034"
-          );
-          if (hydration) xcmVol30d = hydration.volumeUsd;
-        } catch (e) {
-          request.log.warn("Failed to fetch xcm volume", e);
-        }
-
-        const tvl =
-          tvlData.platformTotalTvl.nodes[0]?.totalTvlDecoratedNorm || 0;
+        const stats = await neckworkGet("/hydration-web/v1/stats");
 
         const result = {
-          tvl: Number(tvl),
-          vol_30d: vol30d,
-          xcm_vol_30d: Number(xcmVol30d.toFixed(12)),
-          assets_count: assetsCount,
-          accounts_count: accountsCount,
+          tvl: Number(stats.tvl) || 0,
+          vol_30d: Number(stats.vol_30d) || 0,
+          xcm_vol_30d: Number(stats.xcm_vol_30d) || 0,
+          assets_count: Number(stats.assets_count) || 0,
+          accounts_count: Number(stats.accounts_count) || 0,
         };
 
         await fastify.redis.set(cacheSetting.key, JSON.stringify(result));
         await fastify.redis.expire(cacheSetting.key, cacheSetting.expire_after);
 
-        request.log.info("Final stats response: " + JSON.stringify(result));
-        reply.send(result);
+        return reply.send(result);
       } catch (err) {
-        request.log.error("Failed to compute stats", err);
+        request.log.error(err, "Failed to compute stats");
         return reply.status(500).send({ error: "Stats computation failed" });
       }
     },

--- a/app/routes/lending/v1/caps.mjs
+++ b/app/routes/lending/v1/caps.mjs
@@ -1,153 +1,13 @@
-import { gql, request as gqlRequest } from "graphql-request";
 import { CACHE_SETTINGS } from "../../../../variables.mjs";
+import { neckworkGet } from "../../../../clients/neckwork.mjs";
 
-const GRAPHQL_ENDPOINT =
-  "https://orca-main-aggr-indx.indexer.hydration.cloud/graphql";
-const RPC_URL = "https://hydration-rpc.n.dwellir.com";
-
-const HOLLAR_DECIMALS = 18;
-const HOLLAR_VARIABLE_DEBT_TOKEN = "0x342923782ccaebf9c38dd9cb40436e82c42c73b5";
-
-// ERC20 totalSupply function signature
-const TOTAL_SUPPLY_SIGNATURE = "0x18160ddd";
-
-/**
- * Normalize a value by dividing by 10^decimals
- * @param {string|bigint} value - The value to normalize
- * @param {number} decimals - Number of decimal places
- * @returns {number} The normalized value
- */
-function normalize(value, decimals) {
-  const bigValue = typeof value === "string" ? BigInt(value) : value;
-  const divisor = BigInt(10 ** decimals);
-  const integerPart = bigValue / divisor;
-  const remainder = bigValue % divisor;
-
-  // Format the decimal part with proper padding
-  const decimalPart = remainder.toString().padStart(decimals, "0");
-
-  // Combine and convert to number
-  return parseFloat(`${integerPart}.${decimalPart}`);
-}
-
-/**
- * Call totalSupply function on an ERC20 contract via RPC
- * @param {string} contractAddress - The contract address
- * @returns {Promise<string>} The hex result from the RPC call
- */
-async function callTotalSupply(contractAddress) {
-  const response = await fetch(RPC_URL, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      jsonrpc: "2.0",
-      method: "eth_call",
-      params: [
-        {
-          to: contractAddress,
-          data: TOTAL_SUPPLY_SIGNATURE,
-        },
-        "latest",
-      ],
-      id: 1,
-    }),
-  });
-
-  const data = await response.json();
-
-  if (data.error) {
-    throw new Error(data.error.message || "RPC call failed");
-  }
-
-  return data.result;
-}
-
-/**
- * Fetch Hollar borrow cap from the Aave Facilitator
- * @returns {Promise<number>} Hollar borrow cap
- */
-async function fetchHollarBorrowCap() {
-  const data = await gqlRequest(
-    GRAPHQL_ENDPOINT,
-    gql`
-      query MyQuery {
-        aaveFacilitatorHistoricalData(
-          orderBy: PARA_BLOCK_HEIGHT_DESC
-          condition: {
-            facilitatorId: "0x8c0f3b9602374198974d2b2679d14a386f5b108e"
-          }
-          first: 1
-        ) {
-          nodes {
-            bucketCapacity
-          }
-        }
-      }
-    `
-  );
-
-  const node = data.aaveFacilitatorHistoricalData.nodes[0];
-
-  if (!node) {
-    throw new Error("No Hollar borrow cap data found");
-  }
-
-  return normalize(node.bucketCapacity, HOLLAR_DECIMALS);
-}
-
-/**
- * Fetch Hollar current borrow level from variable debt token total supply
- * @returns {Promise<number>} Hollar current borrow level
- */
-async function fetchHollarCurrentBorrow() {
-  // Call the variable debt token contract via JSON-RPC
-  const hexValue = await callTotalSupply(HOLLAR_VARIABLE_DEBT_TOKEN);
-
-  // Convert hex to BigInt and normalize
-  const rawSupply = BigInt(hexValue);
-
-  return normalize(rawSupply, HOLLAR_DECIMALS);
-}
-
-/**
- * Fetch Hollar token data (cap and current borrow)
- * @returns {Promise<Object>} Hollar token cap data
- */
-async function fetchHollarData() {
-  // Fetch both cap and current borrow in parallel
-  const [capacity, currentBorrow] = await Promise.all([
-    fetchHollarBorrowCap(),
-    fetchHollarCurrentBorrow(),
-  ]);
-
-  const available = capacity - currentBorrow;
-
-  return {
-    asset: "Hydrated Dollar",
-    borrowCap: capacity,
-    currentBorrow: currentBorrow,
-    available: available,
-  };
-}
-
-/**
- * Fetch caps data for all money market assets
- * Currently only returns Hollar, but structured to be extensible
- * @returns {Promise<Array>} Array of asset cap data
- */
-async function fetchCapsData() {
-  // Fetch Hollar data
-  const hollarData = await fetchHollarData();
-
-  // TODO: Add other assets from mmReserveConfigHistoricalData
-  // This structure allows easy extension with additional assets
-  const assets = [hollarData];
-
-  return assets;
-}
-
+// neckwork serves the full money-market cap set off the live indexer,
+// replacing the retired orca aggregation-indexer GraphQL (borrow cap) and the
+// dwellir RPC totalSupply call (current borrow) the old handler stitched
+// together. we keep the historical contract: the core-market HOLLAR
+// facilitator entry, mapped to { asset, borrowCap, currentBorrow, available }.
+// neckwork returns every reserve with richer fields — a future revision can
+// widen this endpoint to expose them.
 export default async (fastify, opts) => {
   fastify.route({
     url: "/caps",
@@ -186,18 +46,31 @@ export default async (fastify, opts) => {
     },
     handler: async (request, reply) => {
       try {
-        let cacheSetting = { ...CACHE_SETTINGS["lendingV1Caps"] };
+        const cacheSetting = CACHE_SETTINGS["lendingV1Caps"];
 
-        // Check cache first
         const cachedResult = await fastify.redis.get(cacheSetting.key);
         if (cachedResult) {
           return reply.send(JSON.parse(cachedResult));
         }
 
-        // Fetch from GraphQL
-        const capsData = await fetchCapsData();
+        const rows = await neckworkGet("/lending/v1/caps");
+        const hollar = Array.isArray(rows)
+          ? rows.find((r) => r.symbol === "HOLLAR" && r.market === "core")
+          : null;
 
-        // Cache the result
+        if (!hollar) {
+          throw new Error("No Hollar borrow cap data found");
+        }
+
+        const capsData = [
+          {
+            asset: "Hydrated Dollar",
+            borrowCap: Number(hollar.borrowCap),
+            currentBorrow: Number(hollar.currentBorrow),
+            available: Number(hollar.available),
+          },
+        ];
+
         await fastify.redis.set(cacheSetting.key, JSON.stringify(capsData));
         await fastify.redis.expire(cacheSetting.key, cacheSetting.expire_after);
 


### PR DESCRIPTION
Both routes queried `orca-main-aggr-indx.indexer.hydration.cloud`, the retired orca aggregation-indexer — now down, so both 500. Repoint them to the neckwork facade (`hydration-api.neckwork.net`), which serves both natively off the live indexer, mirroring the coingecko/defillama migrations.

- **/hydration-web/v1/stats** → `neckworkGet('/hydration-web/v1/stats')`; identical 5-field contract (tvl, vol_30d, xcm_vol_30d, assets_count, accounts_count). Drops the separate ocelloids XCM call — neckwork folds xcm_vol_30d in.
- **/lending/v1/caps** → `neckworkGet('/lending/v1/caps')`, filtered to the core-market HOLLAR facilitator entry; same {asset, borrowCap, currentBorrow, available} shape. Drops the dwellir RPC totalSupply call. (neckwork returns every reserve with richer fields — future revision can widen the endpoint.)

Cache keys/TTLs unchanged. Verified the mapping against live neckwork.